### PR TITLE
Avoid weird paragraph spacing

### DIFF
--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -212,12 +212,12 @@ main a:hover code, main a:focus code {
   background-color: inherit;
 }
 a.bookmark {
-  visibility: hidden;
+  display: none;
 }
 h2:hover a.bookmark,
 h3:hover a.bookmark,
 h4:hover a.bookmark {
-  visibility: visible;
+  display: inline;
 }
 figure {
   margin: 0 0 1em;


### PR DESCRIPTION
Dependent on the width, the hidden bookmark would still consume screen real estate if it would break to a new line as the only word. This fixes the issue seen below:

* Still fitting at 377px width:
  <img width="395" alt="screenshot 2018-10-17 at 10 09 10" src="https://user-images.githubusercontent.com/145676/47073797-5a7cf280-d1f9-11e8-8617-c347ddaa7d35.png">
* Breaking at 375px width:
  <img width="469" alt="screenshot 2018-10-17 at 10 09 27" src="https://user-images.githubusercontent.com/145676/47073798-5a7cf280-d1f9-11e8-8a3a-fde21fa5bd46.png">

The downside is that this will cause a reflow upon hover, but this seems better in comparison to the spacing issue.
