### PR TITLE
Format Torque code examples

### DIFF
--- a/src/docs/torque.md
+++ b/src/docs/torque.md
@@ -202,7 +202,7 @@ type int31 extends int32 generates 'TNode<Int32T>' constexpr 'int31_t';
 Union types express that a value belongs to one of several possible types. We only allow union types for tagged values, because they can be distinguished at runtime using the map pointer. For example, JavaScript numbers are either Smi values or allocated HeapNumber objects.
 
 ```torque
-type Number = Smi|HeapNumber;
+type Number = Smi | HeapNumber;
 ```
 
 Union types satisfy the following equalities:

--- a/src/docs/torque.md
+++ b/src/docs/torque.md
@@ -119,12 +119,12 @@ module array {
 };
 
 module string {
-  …
+  // …
   macro TestVisibility() {
     IsJsObject(o); // OK, global module visible here
     IsJSArray(o);  // ERROR, not visible in this module
   }
-  …
+  // …
 }
 
 module array {
@@ -150,9 +150,9 @@ In this example, `builtins-foo-gen-from-idl.h` declares `FooBuiltinsFromDSLAssem
 
 ```cpp
 class FooBuiltinsFromDSLAssembler: public FooBuiltinsAssembler {
- public:
-  …
-  void Baz();
+  public:
+    // …
+    void Baz();
 };
 ```
 
@@ -202,7 +202,7 @@ type int31 extends int32 generates 'TNode<Int32T>' constexpr 'int31_t';
 Union types express that a value belongs to one of several possible types. We only allow union types for tagged values, because they can be distinguished at runtime using the map pointer. For example, JavaScript numbers are either Smi values or allocated HeapNumber objects.
 
 ```torque
-type Number = Smi | HeapNumber;
+type Number = Smi|HeapNumber;
 ```
 
 Union types satisfy the following equalities:
@@ -308,8 +308,10 @@ Declarations of Torque-defined Callables, e.g. Torque `macro`s and `builtin`s, h
 As an example:
 
 ```torque
- javascript builtin ArraySlice(
-      context: Context, receiver: Object, ...arguments): Object { … }
+javascript builtin ArraySlice(
+    context: Context, receiver: Object, ...arguments): Object {
+  // …
+}
 ```
 
 ### Implicit parameters
@@ -323,7 +325,7 @@ Torque callables can specify implicit parameters using something similar to [Sca
 Concretely: A `macro` can declare implicit parameters in addition to explicit ones:
 
 ```torque
-macro Foo(implicit context : Context)(x: Smi, y: Smi)
+macro Foo(implicit context: Context)(x: Smi, y: Smi)
 ```
 
 When mapping to CSA, implicit parameters and explicit parameters are treated the same and form a joint parameter list.
@@ -331,8 +333,8 @@ When mapping to CSA, implicit parameters and explicit parameters are treated the
 Implicit parameters are not mentioned at the callsite, but instead are passed implicitly: `Foo(4,5)`. For this to work, `Foo(4,5)` must be called in a context that provides a value named `context`. Example:
 
 ```torque
-macro Bar(implicit context : Context)() {
-  Foo(4,5);
+macro Bar(implicit context: Context)() {
+  Foo(4, 5);
 }
 ```
 

--- a/src/docs/torque.md
+++ b/src/docs/torque.md
@@ -330,7 +330,7 @@ macro Foo(implicit context: Context)(x: Smi, y: Smi)
 
 When mapping to CSA, implicit parameters and explicit parameters are treated the same and form a joint parameter list.
 
-Implicit parameters are not mentioned at the callsite, but instead are passed implicitly: `Foo(4,5)`. For this to work, `Foo(4,5)` must be called in a context that provides a value named `context`. Example:
+Implicit parameters are not mentioned at the callsite, but instead are passed implicitly: `Foo(4, 5)`. For this to work, `Foo(4, 5)` must be called in a context that provides a value named `context`. Example:
 
 ```torque
 macro Bar(implicit context: Context)() {


### PR DESCRIPTION
This patch applies the Torque formatter [1] to the code examples in the documentation.

[1] https://v8.dev/docs/torque#torque-tooling