### PR TITLE
Fix typo in trash talk

### DIFF
--- a/src/blog/trash-talk.md
+++ b/src/blog/trash-talk.md
@@ -1,6 +1,6 @@
 ---
 title: 'Trash talk: the Orinoco garbage collector'
-author: Peter ‘the garbo’ Marshall ([@hooraybuffer](https://twitter.com/hooraybuffer))'
+author: Peter ‘the garbo’ Marshall ([@hooraybuffer](https://twitter.com/hooraybuffer))
 avatars:
   - 'peter-marshall'
 date: 2019-01-03 17:15:34


### PR DESCRIPTION
There is a stray single quote at the end of the author line.