### PR TITLE
cquery no longer supports building with waf

### DIFF
--- a/src/docs/ide-setup.md
+++ b/src/docs/ide-setup.md
@@ -25,7 +25,10 @@ Clone cquery from [cquery](https://github.com/cquery-project/cquery) in a direct
 git clone https://github.com/cquery-project/cquery "$CQUERY_DIR"
 cd "$CQUERY_DIR"
 git submodule update --init
-./waf configure build
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=release -DCMAKE_EXPORT_COMPILE_COMMANDS=YES
+make install -j8
 ```
 
 If anything goes wrong, be sure to check out [cquery’s getting started guide](https://github.com/cquery-project/cquery/wiki).

--- a/src/docs/ide-setup.md
+++ b/src/docs/ide-setup.md
@@ -33,7 +33,7 @@ make install -j8
 
 If anything goes wrong, be sure to check out [cquery’s getting started guide](https://github.com/cquery-project/cquery/wiki).
 
-You can use `git pull && git submodule update` to update cquery at a later time (don't forget to rebuild via `./waf configure build`).
+You can use `git pull && git submodule update` to update cquery at a later time (don't forget to rebuild via `cmake .. -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=release -DCMAKE_EXPORT_COMPILE_COMMANDS=YES && make install -j8`).
 
 ### Install and configure cquery-plugin for VSCode
 


### PR DESCRIPTION
see: https://github.com/cquery-project/cquery/commit/236118e5cfaf0fef38b496b124c99adc1e880aca#diff-47342d1bee153385294760bddb8a7f49

if I run `./waf`:
```
cquery no longer supports building with waf. Please use cmake instead.

Here is a quick getting-started:

  # remove previous waf build directory
  $ rm -rf build
  
  # setup new cmake build directory
  $ mkdir build
  $ cd build
  $ cmake .. -DCMAKE_BUILD_TYPE=release -DCMAKE_INSTALL_PREFIX=release -DCMAKE_EXPORT_COMPILE_COMMANDS=YES
  $ make install -j8

See https://github.com/cquery-project/cquery/wiki/Building-cquery for more details
```