### PR TITLE
Updating layout tests docs

### DIFF
--- a/src/docs/blink-layout-tests.md
+++ b/src/docs/blink-layout-tests.md
@@ -5,11 +5,11 @@ We continuously run [Blink’s web tests (formerly known as “layout tests”)]
 
 On test failures, the bots compare the results of V8 Tip-of-Tree with Chromium’s pinned V8 version, to only flag newly introduced V8 problems (with false positives < 5%). Blame assignment is trivial as the [Linux release](https://ci.chromium.org/p/v8/builders/luci.v8.ci/V8-Blink%20Linux%2064) bot tests all revisions.
 
-Commits with newly introduced failures are normally reverted to unblock auto-rolling into Chromium. In case you break layout tests and the changes are expected, follow this procedure to add updated baselines to Chromium, in order to be able to reland your CL:
+Commits with newly introduced failures are normally reverted to unblock auto-rolling into Chromium. In case you notice you break layout tests or your commit gets reverted because of such breakage, and in case the changes are expected, follow this procedure to add updated baselines to Chromium before (re-)landing your CL:
 
 1. Land a Chromium change setting `[ Failure Pass ]` for the changed tests ([more](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#updating-the-expectations-files)).
 1. Land your V8 CL and wait 1-2 days until it cycles into Chromium.
-1. Follow [this automatic procedure](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#how-to-rebaseline) to generate the new baselines. In case it doesn't work for you, you can still fall back to updating the baselines manually by following [these instructions](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_tests.md#Rebaselining-Web-Tests).
+1. Follow [these instructions](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_tests.md#Rebaselining-Web-Tests) to manually generate the new baselines. Note that if you're making changes only to Chromium, [this preffered automatic procedure](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#how-to-rebaseline) should work for you.
 1. Remove the `[ Failure Pass ]` entry from the test expectations file and commit it along with the new baselines in Chromium.
 
 Please associate all CLs with a `BUG=…`.

--- a/src/docs/blink-layout-tests.md
+++ b/src/docs/blink-layout-tests.md
@@ -5,10 +5,11 @@ We continuously run [Blink’s web tests (formerly known as “layout tests”)]
 
 On test failures, the bots compare the results of V8 Tip-of-Tree with Chromium’s pinned V8 version, to only flag newly introduced V8 problems (with false positives < 5%). Blame assignment is trivial as the [Linux release](https://ci.chromium.org/p/v8/builders/luci.v8.ci/V8-Blink%20Linux%2064) bot tests all revisions.
 
-Commits with newly introduced failures are normally reverted to unblock auto-rolling into Chromium. In case you break layout tests and the changes are expected, follow this procedure:
+Commits with newly introduced failures are normally reverted to unblock auto-rolling into Chromium. In case you break layout tests and the changes are expected, follow this procedure to add updated baselines to Chromium, in order to be able to reland your CL:
 
-1. Land a Chromium change setting `[ Failure Pass ]` for the changed tests ([more](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#How-to-rebaseline)).
+1. Land a Chromium change setting `[ Failure Pass ]` for the changed tests ([more](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#updating-the-expectations-files)).
 1. Land your V8 CL and wait 1-2 days until it cycles into Chromium.
-1. Switch `[ Failure Pass ]` to `[ NeedsRebaseline ]` in Chromium. Tests will be automatically rebaselined.
+1. Follow [this automatic procedure](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#how-to-rebaseline) to generate the new baselines. In case it doesn't work for you, you can still fall back to updating the baselines manually by following [these instructions](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_tests.md#Rebaselining-Web-Tests).
+1. Remove the `[ Failure Pass ]` entry from the test expectations file and commit it along with the new baselines in Chromium.
 
 Please associate all CLs with a `BUG=…`.

--- a/src/docs/blink-layout-tests.md
+++ b/src/docs/blink-layout-tests.md
@@ -5,11 +5,11 @@ We continuously run [Blink’s web tests (formerly known as “layout tests”)]
 
 On test failures, the bots compare the results of V8 Tip-of-Tree with Chromium’s pinned V8 version, to only flag newly introduced V8 problems (with false positives < 5%). Blame assignment is trivial as the [Linux release](https://ci.chromium.org/p/v8/builders/luci.v8.ci/V8-Blink%20Linux%2064) bot tests all revisions.
 
-Commits with newly introduced failures are normally reverted to unblock auto-rolling into Chromium. In case you notice you break layout tests or your commit gets reverted because of such breakage, and in case the changes are expected, follow this procedure to add updated baselines to Chromium before (re-)landing your CL:
+Commits with newly-introduced failures are normally reverted to unblock auto-rolling into Chromium. In case you notice you break layout tests or your commit gets reverted because of such breakage, and in case the changes are expected, follow this procedure to add updated baselines to Chromium before (re-)landing your CL:
 
 1. Land a Chromium change setting `[ Failure Pass ]` for the changed tests ([more](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#updating-the-expectations-files)).
 1. Land your V8 CL and wait 1-2 days until it cycles into Chromium.
-1. Follow [these instructions](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_tests.md#Rebaselining-Web-Tests) to manually generate the new baselines. Note that if you're making changes only to Chromium, [this preffered automatic procedure](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#how-to-rebaseline) should work for you.
+1. Follow [these instructions](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_tests.md#Rebaselining-Web-Tests) to manually generate the new baselines. Note that if you’re making changes only to Chromium, [this preferred automatic procedure](https://chromium.googlesource.com/chromium/src/+/master/docs/testing/web_test_expectations.md#how-to-rebaseline) should work for you.
 1. Remove the `[ Failure Pass ]` entry from the test expectations file and commit it along with the new baselines in Chromium.
 
 Please associate all CLs with a `BUG=…`.


### PR DESCRIPTION
Added up-to-date info about our manual procedure for updating the baselines when a commit in V8 breaks layout tests in Chromium.

Mathias, PTAL and big thanks to @xtuc for the valuable comments on the procedure!