### PR TITLE
fix: Quote glob for Markdownlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "lint": "markdownlint src/**/*.md",
+    "lint": "markdownlint \"src/**/*.md\"",
     "eleventy": "eleventy",
     "html": "html-minifier --config-file=.html-minifier.json --input-dir=dist --output-dir=dist --file-ext=html",
     "css": "postcss src/_css/main.css --output dist/_css/main.css",

--- a/src/404.md
+++ b/src/404.md
@@ -4,6 +4,6 @@ permalink: /404.html
 excludeFromSitemap: true
 layout: layouts/base.njk
 ---
-# 404: document not found
+## 404: document not found
 
 Sorry, we couldn’t find that page.

--- a/src/logo.md
+++ b/src/logo.md
@@ -3,11 +3,11 @@ permalink: /logo/
 title: V8 logos
 layout: layouts/base.njk
 ---
-# V8 logos
+## V8 logos
 
 Download the official V8 logos here in vector format (SVG). The SVG files have been minified and optimized for online usage.
 
-## V8
+### V8
 
 <a href="/_img/v8.svg" class="logo-download" download>
   <figure>
@@ -22,7 +22,7 @@ Download the official V8 logos here in vector format (SVG). The SVG files have b
   </figure>
 </a>
 
-## Ignition
+### Ignition
 
 <a href="/_img/v8-ignition.svg" class="logo-download" download>
   <figure>
@@ -37,7 +37,7 @@ Download the official V8 logos here in vector format (SVG). The SVG files have b
   </figure>
 </a>
 
-## TurboFan
+### TurboFan
 
 <a href="/_img/v8-turbofan.svg" class="logo-download" download>
   <figure>
@@ -52,7 +52,7 @@ Download the official V8 logos here in vector format (SVG). The SVG files have b
   </figure>
 </a>
 
-## Liftoff
+### Liftoff
 
 <a href="/_img/v8-liftoff.svg" class="logo-download" download>
   <figure>
@@ -67,7 +67,7 @@ Download the official V8 logos here in vector format (SVG). The SVG files have b
   </figure>
 </a>
 
-## Orinoco
+### Orinoco
 
 <a href="/_img/v8-orinoco.svg" class="logo-download" download>
   <figure>

--- a/src/terms.md
+++ b/src/terms.md
@@ -2,15 +2,15 @@
 title: 'Terms of service'
 layout: layouts/base.njk
 ---
-# Terms of service
+## Terms of service
 
 By using the official V8 website (the “Service”), you agree to be bound by our Google Terms of Services located at <https://www.google.com/accounts/TOS> as well as these additional terms. Google may change these terms from time to time and post any modified terms at <https://v8.dev/terms>. You understand and agree that if you use the Service after the date on which these terms have changed, Google treats your use as acceptance of the updated terms.
 
-## Code of conduct
+### Code of conduct
 
 As part of the Chromium team, the V8 team is committed to preserving and fostering a diverse, welcoming community. To this end, the [Chromium Code of Conduct](https://chromium.googlesource.com/chromium/src/+/master/CODE_OF_CONDUCT.md) applies to our website, repositories, organizations, mailing lists, and any other Chromium-supported communication groups, as well as any private communication initiated in the context of these spaces.
 
-## Site policies
+### Site policies
 
 We are pleased to license much of the documentation on the official V8 website under terms that explicitly encourage people to take, modify, reuse, re-purpose, and remix our work as they see fit.
 
@@ -21,7 +21,7 @@ Many pages on the V8 website contain the following notice:
 When you see a page with this notice you are free to use [nearly everything](#restrictions) on the page in your own creations. For example, you could quote the text in a book, cut-and-paste sections to your blog, record it as an audiobook for the visually impaired, or even translate it into Swahili. Really. That’s what open content licenses are all about. We just ask that you give us attribution when you reuse our work.
 In addition, you are free to use the computer source code that appears in the content (such as in examples) in the code of your own projects. This applies to any source code from the V8 project as well, as long as [its license](https://chromium.googlesource.com/v8/v8.git/+/master/LICENSE) is respected.
 
-### What is _not_ licensed?
+#### What is _not_ licensed?
 
 We say “nearly everything” as there are a few simple conditions that apply.
 
@@ -29,7 +29,7 @@ Google’s trademarks and other brand features are not included in this license.
 
 In some cases, a page may include content consisting of images, audio, or video material, or a link to content on a different webpage (such as videos or slide decks). This content is not covered by the license, unless specifically noted.
 
-### Attribution
+#### Attribution
 
 Proper attribution is required when you reuse or create modified versions of content that appears on a page made available under the terms of the Creative Commons Attribution license. The complete requirements for attribution can be found in [section 4 of the Creative Commons legal code](https://creativecommons.org/licenses/by/3.0/legalcode).
 
@@ -37,7 +37,7 @@ In practice we ask that you provide attribution to the V8 project to the best of
 
 There are several typical ways in which this might apply:
 
-#### Exact reproductions
+##### Exact reproductions
 
 If your online work exactly reproduces text or images from this site, in whole or in part, please include a paragraph at the bottom of your page that reads:
 
@@ -45,7 +45,7 @@ If your online work exactly reproduces text or images from this site, in whole o
 
 Also, please link back to the original source page so that readers can refer to it for more information.
 
-#### Modified versions
+##### Modified versions
 
 If your online work shows modified text or images based on the content from this site, please include a paragraph at the bottom of your page that reads:
 
@@ -53,6 +53,6 @@ If your online work shows modified text or images based on the content from this
 
 Again, please link back to the original source page so that readers can refer to it for more information. This is even more important when the content has been modified.
 
-#### Other media
+##### Other media
 
 If you produce non-hypertext works, such as books, audio, or video, we ask that you make a best effort to include a spoken or written attribution in the spirit of the messages above.


### PR DESCRIPTION

Markdownlint globs require the quotes to be expanded.
Address the flagged heading start issues by reflowing from H1->H2.