### PR TITLE
Fix and upgrade Markdownlint config

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,10 +1,10 @@
 {
   "default": true,
-  "MD002": { "level": 2 },
   "MD003": { "style": "atx" },
   "MD004": { "style": "dash" },
   "MD007": { "indent": 4 },
   "MD013": false,
+  "MD025": { "front_matter_title": "" },
   "MD026": { "punctuation": ".,;:!" },
   "MD033": false,
   "MD040": false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "lint": "markdownlint src/**/*.md",
+    "lint": "markdownlint \"src/**/*.md\"",
     "eleventy": "eleventy",
     "html": "html-minifier --config-file=.html-minifier.json --input-dir=dist --output-dir=dist --file-ext=html",
     "css": "postcss src/_css/main.css --output dist/_css/main.css && postcss src/_css/feature-support.css --output dist/_css/feature-support.css",


### PR DESCRIPTION
As #184 has shown, the lint command was ignored on Linux due to specifics of glob expansion. Now that the glob is quoted, it works correctly across all platforms and actually reports errors.

Also, Markdownlint had issues with MD002 rule, which was deprecated in the new version in favour of MD041, so I upgraded Markdownlint to pick up these changes.

Also, MD025 was reporting violations for clash between YAML `title:` and the actual heading, which is now disabled in the config.

This supersedes #184.