### PR TITLE
Enable Windows CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 os:
   - linux
   - osx
-  # - windows - doesn't work for now, see https://github.com/jasongin/nvs/issues/113#issuecomment-521211564
+  - windows
 script:
   - npm run ci
   - |


### PR DESCRIPTION
nvs now added support for reading versions from `.nvmrc` (https://github.com/jasongin/nvs/issues/113), and Travis already upgraded to this newest nvs version, so we can re-enable Windows CI again.