### PR TITLE
Clarify recommendations regarding .mjs

### DIFF
--- a/src/features/dynamic-import.md
+++ b/src/features/dynamic-import.md
@@ -42,7 +42,7 @@ Here’s how to statically import and use the `./utils.mjs` module:
 ```
 
 :::note
-**Note:** The previous example uses the `.mjs` extension to signal that it’s a module rather than a regular script. On the web, file extensions don’t really matter, as long as the files are served with the correct MIME type (e.g. `text/javascript` for JavaScript files) in the `Content-Type` HTTP header. The `.mjs` extension is [especially useful](https://github.com/nodejs/node-eps/blob/master/002-es-modules.md#32-determining-if-source-is-an-es-module) on other platforms such as Node.js, where there’s no concept of MIME types or other mandatory hooks such as `type="module"` to determine whether something is a module or a regular script. We’re using the same extension here for consistency across platforms and to clearly make the distinction between modules and regular scripts.
+**Note:** The previous example uses the `.mjs` extension to signal that it’s a module rather than a regular script. On the web, file extensions don’t really matter, as long as the files are served with the correct MIME type (e.g. `text/javascript` for JavaScript files) in the `Content-Type` HTTP header.
 :::
 
 This syntactic form for importing modules is a *static* declaration: it only accepts a string literal as the module specifier, and introduces bindings into the local scope via a pre-runtime “linking” process. The static `import` syntax can only be used at the top-level of the file.

--- a/src/features/dynamic-import.md
+++ b/src/features/dynamic-import.md
@@ -42,7 +42,7 @@ Here’s how to statically import and use the `./utils.mjs` module:
 ```
 
 :::note
-**Note:** The previous example uses the `.mjs` extension to signal that it’s a module rather than a regular script. On the web, file extensions don’t really matter, as long as the files are served with the correct MIME type (e.g. `text/javascript` for JavaScript files) in the `Content-Type` HTTP header.
+**Note:** The previous example uses the `.mjs` extension to signal that it’s a module rather than a regular script. On the web, file extensions don’t really matter, as long as the files are served with the correct MIME type (e.g. `text/javascript` for JavaScript files) in the `Content-Type` HTTP header. The `.mjs` extension is especially useful on other platforms such as [Node.js](https://nodejs.org/api/esm.html#esm_enabling) and [`d8`](/docs/d8), where it’s a convenient way to indicate to the runtime that your code is a module. We’re using the same extension here for consistency across platforms and to clearly make the distinction between modules and regular scripts.
 :::
 
 This syntactic form for importing modules is a *static* declaration: it only accepts a string literal as the module specifier, and introduces bindings into the local scope via a pre-runtime “linking” process. The static `import` syntax can only be used at the top-level of the file.

--- a/src/features/modules.md
+++ b/src/features/modules.md
@@ -126,9 +126,17 @@ Another difference relates to the `async` attribute, which causes the script to 
 
 You may have noticed we’re using the `.mjs` file extension for modules. On the Web, the file extension doesn’t really matter, as long as the file is served with [the JavaScript MIME type `text/javascript`](https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages:javascript-mime-type). The browser knows it’s a module because of the `type` attribute on the script element.
 
-During development, the `.mjs` file extension makes it crystal clear that a file is a module as opposed to a regular script. (It’s not always possible to tell just by looking at the code.) As mentioned before, modules are treated differently than regular scripts, so the difference is hugely important! Additionally, you may want to configure your editor to treat `.mjs` files as `.js` files to get syntax highlighting. Most modern editors already do this by default.
+In production, you should name your files with an `.mjs` extension only if you are sure that they will be served with the required `Content-Type: text/javascript` header. If your host lacks such support, or if you are publishing open source JavaScript for public use by others, it’s safer to use the `.js` extension.
 
-In production, you should save your files with an `.mjs` extension only if you are sure that they will be served with the required `Content-Type: text/javascript` header. If your host lacks such support, or if you are publishing open source JavaScript for public use by others, it’s safer to use the `.js` extension.
+During development, we recommend using the `.mjs` extension for modules, for two reasons:
+
+1. The `.mjs` extension makes it crystal clear to you and anyone else looking at your project that the file is a module as opposed to a regular script. (It’s not always possible to tell just by looking at the code.) As mentioned before, modules are treated differently than regular scripts, so the difference is hugely important!
+
+1. It ensures that your file is parsed as a module by runtimes such as [Node.js](https://nodejs.org/api/esm.html#esm_enabling) and [`d8`](/docs/d8), and build tools such as [Babel](https://babeljs.io/docs/en/options#sourcetype). While these environments and tools each have proprietary ways via configuration to interpret `.js` files as modules, the `.mjs` extension is the cross-compatible way to ensure that files are treated as modules.
+
+:::note
+**Note:** You may want to configure your editor to treat `.mjs` files as `.js` files to get syntax highlighting. Most modern editors already do this by default.
+:::
 
 ### Module specifiers { #specifiers }
 

--- a/src/features/modules.md
+++ b/src/features/modules.md
@@ -126,14 +126,9 @@ Another difference relates to the `async` attribute, which causes the script to 
 
 You may have noticed we’re using the `.mjs` file extension for modules. On the Web, the file extension doesn’t really matter, as long as the file is served with [the JavaScript MIME type `text/javascript`](https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages:javascript-mime-type). The browser knows it’s a module because of the `type` attribute on the script element.
 
-Still, we recommend using the `.mjs` extension for modules, for two reasons:
+During development, the `.mjs` file extension makes it crystal clear that a file is a module as opposed to a regular script. (It’s not always possible to tell just by looking at the code.) As mentioned before, modules are treated differently than regular scripts, so the difference is hugely important! Additionally, you may want to configure your editor to treat `.mjs` files as `.js` files to get syntax highlighting. Most modern editors already do this by default.
 
-1. During development, it makes it crystal clear that the file is a module as opposed to a regular script. (It’s not always possible to tell just by looking at the code.) As mentioned before, modules are treated differently than regular scripts, so the difference is hugely important!
-1. It’s consistent with Node.js, where [the experimental modules implementation](https://nodejs.org/api/esm.html) only supports files with the `.mjs` extension by default.
-
-:::note
-**Note:** To deploy `.mjs` on the web, your web server needs to be configured to serve files with this extension using the appropriate `Content-Type: text/javascript` header, as mentioned above. Additionally, you may want to configure your editor to treat `.mjs` files as `.js` files to get syntax highlighting. Most modern editors already do this by default.
-:::
+In production, you should save your files with an `.mjs` extension only if you are sure that they will be served with the required `Content-Type: text/javascript` header. If your host lacks such support, or if you are publishing open source JavaScript for public use by others, it’s safer to use the `.js` extension.
 
 ### Module specifiers { #specifiers }
 


### PR DESCRIPTION
Resolves https://github.com/google/WebFundamentals/issues/7623.

The `.mjs` extension is a perfectly valid recommendation for development, but users should not be encouraged to publish JavaScript files with an `.mjs` extension unless they’re sure that such files will be served with the proper MIME type.