### PR TITLE
Update Firefox support for public class fields

### DIFF
--- a/src/features/class-fields.md
+++ b/src/features/class-fields.md
@@ -190,7 +190,7 @@ class Cat extends Animal {
 ### Support for public class fields { #support-public-fields }
 
 <feature-support chrome="72 /blog/v8-release-72#public-class-fields"
-                 firefox="no"
+                 firefox="69 https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69#JavaScript"
                  safari="no"
                  nodejs="12 https://twitter.com/mathias/status/1120700101637353473"
                  babel="no"></feature-support>

--- a/src/features/class-fields.md
+++ b/src/features/class-fields.md
@@ -190,7 +190,7 @@ class Cat extends Animal {
 ### Support for public class fields { #support-public-fields }
 
 <feature-support chrome="72 /blog/v8-release-72#public-class-fields"
-                 firefox="69 https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69#JavaScript"
+                 firefox="partial https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69#JavaScript"
                  safari="no"
                  nodejs="12 https://twitter.com/mathias/status/1120700101637353473"
                  babel="no"></feature-support>


### PR DESCRIPTION
Firefox added support for public class fields as of the release 69

See https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/69#JavaScript