### PR TITLE
Re-remove comments from output

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,5 +4,6 @@
       "topLevel": true
     }
   }]],
-  "plugins": ["@babel/plugin-syntax-dynamic-import"]
+  "plugins": ["@babel/plugin-syntax-dynamic-import"],
+  "comments": false
 }


### PR DESCRIPTION
They were accidentally enabled in #266, so disabling them again.

This cuts `main.mjs.gz` size down from 1294 bytes to 780 bytes (before the initial PR: 700 bytes).