### PR TITLE
Fix Google Analytics

### DIFF
--- a/src/_js/main.mjs
+++ b/src/_js/main.mjs
@@ -104,4 +104,6 @@ ga.q = [];
 ga('create', UA_ID, 'auto');
 ga('set', 'referrer', document.referrer.split('?')[0]);
 ga('send', 'pageview');
-import('https://www.google-analytics.com/analytics.js');
+const gaScript = document.createElement('script');
+gaScript.src = 'https://www.google-analytics.com/analytics.js';
+document.head.appendChild(gaScript);


### PR DESCRIPTION
`import` works only with CORS headers, which are not sent by GA script.

Ref: https://github.com/v8/v8.dev/pull/266/files#r339317674