### PR TITLE
Lint only staged Markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,11 @@
     "hooks": {
       "post-merge": "post-npm-install",
       "post-rebase": "post-npm-install",
-      "pre-commit": "npm run lint"
+      "pre-commit": "lint-staged"
     }
+  },
+  "lint-staged": {
+    "*.md": "markdownlint"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.8.3",
@@ -45,6 +48,7 @@
     "husky": "^3.0.4",
     "image-size": "^0.7.4",
     "json-minify": "^1.0.0",
+    "lint-staged": "^9.4.2",
     "luxon": "^1.17.2",
     "markdown-it": "^9.1.0",
     "markdown-it-anchor": "^5.2.4",


### PR DESCRIPTION
Speeds up commit hook by avoiding linting of all Markdown files in the blog.