### PR TITLE
Make inverted dark-mode figures backgrounds more accurate

### DIFF
--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -73,7 +73,7 @@
 
 :root.dark figure img[src*=".png"]:not(.no-darkening),
 :root.dark figure img[src*=".svg"]:not(.no-darkening) {
-  filter: invert(0.85) hue-rotate(180deg);
+  filter: invert(0.862745) hue-rotate(180deg);
 }
 
 * {


### PR DESCRIPTION
Set the inversion ratio to 1 - 35/255, to make images with white backgrounds blend in to the dark-mode background more accurately.