### PR TITLE
Bump installed version of `<dark-mode-toggle>`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@browser-logos/safari": "^1.0.4",
     "autoprefixer": "^9.6.1",
     "cssnano": "^4.1.10",
-    "dark-mode-toggle": "^0.4.10",
+    "dark-mode-toggle": "^0.5.0",
     "firebase-tools": "^7.2.4",
     "glob": "^7.1.4",
     "he": "^1.2.0",

--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -425,8 +425,8 @@ img {
 }
 
 dark-mode-toggle {
-  --dark-mode-toggle-light-icon: url(/_css/img/sun.svg);
-  --dark-mode-toggle-dark-icon: url(/_css/img/moon.svg);
+  --dark-mode-toggle-light-icon: url(/_css/img/moon.svg);
+  --dark-mode-toggle-dark-icon: url(/_css/img/sun.svg);
   --dark-mode-toggle-color: var(--main-and-footer-link-color);
   --dark-mode-toggle-icon-filter: invert(80%);
   margin-left: 1em;


### PR DESCRIPTION
The new release fixes a bug with non-hover devices that led to the toggle leaving too much bottom margin.