### PR TITLE
Make too long code wrap

### DIFF
--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -161,9 +161,6 @@ a {
   width: 100%;
   height: 600px;
 }
-h1 code {
-  overflow-wrap: break-word;
-}
 main, #footer {
   background: var(--main-background);
   padding: 1em var(--offset);
@@ -248,6 +245,7 @@ code {
   padding: 1px 2px;
   tab-size: 2;
   background: rgba(0, 0, 0, 0.07);
+  overflow-wrap: break-word;
 }
 pre code {
   border: 0;

--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -161,6 +161,9 @@ a {
   width: 100%;
   height: 600px;
 }
+h1 code {
+  overflow-wrap: break-word;
+}
 main, #footer {
   background: var(--main-background);
   padding: 1em var(--offset);


### PR DESCRIPTION
This will *occasionally* break words in the middle, but this is still *way better* than the overflows. It will do its best to avoid breaks.

Fixes #281 

![Screen Shot 2019-12-18 at 11 20 29](https://user-images.githubusercontent.com/145676/71077835-817dde00-2188-11ea-8411-ea61fd297452.png)
