### PR TITLE
Conditionally include PWACompat

### DIFF
--- a/src/_js/main.mjs
+++ b/src/_js/main.mjs
@@ -111,6 +111,7 @@ document.head.appendChild(gaScript);
 // On Apple mobile devices add the proprietary app icon and splashscreen markup.
 // No one should have to do this manually, and eventually this annoyance will
 // go away once https://bugs.webkit.org/show_bug.cgi?id=183937 is fixed.
-if (/\b(iPad|iPhone|iPod)\b/.test(navigator.userAgent)) {
+if ((/\b(iPad|iPhone|iPod)\b/.test(navigator.userAgent)) &&
+    (!matchMedia('(display-mode: standalone)').matches)) {
   import('https://unpkg.com/pwacompat');
 }

--- a/src/_js/main.mjs
+++ b/src/_js/main.mjs
@@ -111,7 +111,6 @@ document.head.appendChild(gaScript);
 // On Apple mobile devices add the proprietary app icon and splashscreen markup.
 // No one should have to do this manually, and eventually this annoyance will
 // go away once https://bugs.webkit.org/show_bug.cgi?id=183937 is fixed.
-if ((/\b(iPad|iPhone|iPod)\b/.test(navigator.userAgent)) &&
-    (!matchMedia('(display-mode: standalone)').matches)) {
+if (/\b(iPad|iPhone|iPod)\b/.test(navigator.userAgent)) {
   import('https://unpkg.com/pwacompat');
 }

--- a/src/_js/main.mjs
+++ b/src/_js/main.mjs
@@ -107,3 +107,10 @@ ga('send', 'pageview');
 const gaScript = document.createElement('script');
 gaScript.src = 'https://www.google-analytics.com/analytics.js';
 document.head.appendChild(gaScript);
+
+// On Apple mobile devices add the proprietary app icon and splashscreen markup.
+// No one should have to do this manually, and eventually this annoyance will
+// go away once https://bugs.webkit.org/show_bug.cgi?id=183937 is fixed.
+if (/\b(iPad|iPhone|iPod)\b/.test(navigator.userAgent)) {
+  import('https://unpkg.com/pwacompat');
+}


### PR DESCRIPTION
On Apple mobile devices add the proprietary app icon and splashscreen markup. No one should have to do this manually, and eventually this annoyance will go away once https://bugs.webkit.org/show_bug.cgi?id=183937 is fixed.

Fixes #275