### PR TITLE
Mention the status of `await` inside of modules

### DIFF
--- a/src/features/modules.md
+++ b/src/features/modules.md
@@ -82,6 +82,8 @@ Modules are a little different from classic scripts:
 
 - The new static `import` and `export` syntax is only available within modules — it doesn’t work in classic scripts.
 
+- `await` cannot be used as a variable name anywhere in a module - variables in classic scripts can be named `await` outside of async functions.
+
 Because of these differences, *the same JavaScript code might behave differently when treated as a module vs. a classic script*. As such, the JavaScript runtime needs to know which scripts are modules.
 
 ## Using JS modules in the browser { #browser }

--- a/src/features/modules.md
+++ b/src/features/modules.md
@@ -82,7 +82,7 @@ Modules are a little different from classic scripts:
 
 - The new static `import` and `export` syntax is only available within modules — it doesn’t work in classic scripts.
 
-- `await` cannot be used as a variable name anywhere in a module - variables in classic scripts can be named `await` outside of async functions.
+- [Top-level `await`](/features/top-level-await) is available in modules, but not in classic scripts. Relatedly, `await` cannot be used as a variable name anywhere in a module, although variables in classic scripts _can_ be named `await` outside of async functions.
 
 Because of these differences, *the same JavaScript code might behave differently when treated as a module vs. a classic script*. As such, the JavaScript runtime needs to know which scripts are modules.
 


### PR DESCRIPTION
Tried to also cram in a mention of "more differences when compared to CommonJS" but couldn't find a good way to fit that into the flow.

/cc @mathiasbynens