### PR TITLE
Fix link and usage of V8_DEPRECATED

### DIFF
--- a/src/docs/api.md
+++ b/src/docs/api.md
@@ -22,7 +22,7 @@ The embedder should be able to adjust their code to the new API while still usin
 
 - Adding new types, constants, and functions is safe with one caveat: do not add a new pure virtual function to an existing class. New virtual functions should have default implementation.
 - Adding a new parameter to a function is safe if the parameter has the default value.
-  - Removing or renaming types, constants, functions is unsafe. Use the [`V8_DEPRECATED`](https://cs.chromium.org/chromium/src/v8/include/v8config.h?l=395&rcl=0425b20ad9a8ba38c2e0dd16e8814abb722bfdde) and [`V8_DEPRECATE_SOON`](https://cs.chromium.org/chromium/src/v8/include/v8config.h?l=403&rcl=0425b20ad9a8ba38c2e0dd16e8814abb722bfdde) macros, which causes compile-time warnings when the deprecated methods are called by the embedder. For example, let’s say we want to rename function `foo` to function `bar`. Then we need to do the following:
+- Removing or renaming types, constants, functions is unsafe. Use the [`V8_DEPRECATED`](https://cs.chromium.org/chromium/src/v8/include/v8config.h?l=395&rcl=0425b20ad9a8ba38c2e0dd16e8814abb722bfdde) and [`V8_DEPRECATE_SOON`](https://cs.chromium.org/chromium/src/v8/include/v8config.h?l=403&rcl=0425b20ad9a8ba38c2e0dd16e8814abb722bfdde) macros, which causes compile-time warnings when the deprecated methods are called by the embedder. For example, let’s say we want to rename function `foo` to function `bar`. Then we need to do the following:
     - Add the new function `bar` near the existing function `foo`.
     - Wait until the CL rolls in Chrome. Adjust Chrome to use `bar`.
     - Annotate `foo` with `V8_DEPRECATED("Use bar instead") void foo();`

--- a/src/docs/api.md
+++ b/src/docs/api.md
@@ -22,10 +22,10 @@ The embedder should be able to adjust their code to the new API while still usin
 
 - Adding new types, constants, and functions is safe with one caveat: do not add a new pure virtual function to an existing class. New virtual functions should have default implementation.
 - Adding a new parameter to a function is safe if the parameter has the default value.
-- Removing or renaming types, constants, functions is unsafe. Use the [`V8_DEPRECATED`](https://cs.chromium.org/chromium/src/v8/include/v8config.h?rcl=6a01631187415688fdebf0c6aa5993c7f1b47b6f&l=316) and [`V8_DEPRECATE_SOON`](https://cs.chromium.org/chromium/src/v8/include/v8config.h?rcl=6a01631187415688fdebf0c6aa5993c7f1b47b6f&l=332) macros, which causes compile-time warnings when the deprecated methods are called by the embedder. For example, let’s say we want to rename function `foo` to function `bar`. Then we need to do the following:
+  - Removing or renaming types, constants, functions is unsafe. Use the [`V8_DEPRECATED`](https://cs.chromium.org/chromium/src/v8/include/v8config.h?l=395&rcl=0425b20ad9a8ba38c2e0dd16e8814abb722bfdde) and [`V8_DEPRECATE_SOON`](https://cs.chromium.org/chromium/src/v8/include/v8config.h?l=403&rcl=0425b20ad9a8ba38c2e0dd16e8814abb722bfdde) macros, which causes compile-time warnings when the deprecated methods are called by the embedder. For example, let’s say we want to rename function `foo` to function `bar`. Then we need to do the following:
     - Add the new function `bar` near the existing function `foo`.
     - Wait until the CL rolls in Chrome. Adjust Chrome to use `bar`.
-    - Annotate `foo` with `V8_DEPRECATED("Use bar instead", void foo());`
+    - Annotate `foo` with `V8_DEPRECATED("Use bar instead") void foo();`
     - In the same CL adjust the tests that use `foo` to use `bar`.
     - Write in CL motivation for the change and high-level update instructions.
     - Wait until the next V8 branch.


### PR DESCRIPTION
The codesearch links were not working any more, thus they are updated. The code example is wrong since https://crrev.com/c/1847361.