### PR TITLE
Update useful commands in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ This repository hosts the source code of [v8.dev, the official website of the V8
 `npm run` shows the full list of supported commands. Highlights:
 
 - `npm run build` builds the site into `dist`.
-- `npm run watch` builds the site into `dist` and watches for changes.
-- `npm start` kicks off a local HTTP server.
+- `npm run serve` kicks off a local HTTP server and watches for changes.
+- `npm run lint` to run markdownlint.


### PR DESCRIPTION
Instead of running `npm start` followed by `npm run watch`, one can do both
using `npm run serve` so mention that in the README.

Also, how to run the markdown linter is useful.