### PR TITLE
Fix video styling

### DIFF
--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -345,31 +345,29 @@ blockquote {
 figcaption {
   font-size: 0.9em;
 }
-iframe {
-  border: 0;
-  width: 100%;
-}
-iframe + h2, iframe + h3 {
-  margin-top: 1em;
-}
 /* https://alistapart.com/article/creating-intrinsic-ratios-for-video */
 .video {
   position: relative;
-  padding-bottom: 56.25%; /* 16:9 */
+  padding-bottom: 100%;
   padding-top: 25px;
   margin-bottom: 0.5em;
   height: 0;
 }
-/* If we ever need other ratios, add them like so:
 .video-16\:9 {
   padding-bottom: 56.25%;
 }
-*/
-.video iframe {
+.video-25\:9 {
+  padding-bottom: 36%;
+}
+.video iframe, .video video {
   position: absolute;
   top: 0;
   left: 0;
   height: 100%;
+}
+iframe, video {
+  border: 0;
+  width: 100%;
 }
 .table-wrapper {
   overflow-x: auto;

--- a/src/features/simd.md
+++ b/src/features/simd.md
@@ -120,25 +120,33 @@ As per their description, MediaPipe is a framework for building multimodal (eg. 
 One of the most visually appealing demos where it’s easy to observe the difference in performance SIMD makes, is a following hand-tracking system. Without SIMD, you can get only around 3 frames per second on a modern laptop, while with SIMD enabled you get a much smoother experience at 15-16 frames per second.
 
 <figure>
-  <video autoplay muted playsinline loop src="/_img/simd/hand.mp4"></video>
+  <div class="video video-25:9">
+    <video autoplay muted playsinline loop width="600" height="216" src="/_img/simd/hand.mp4"></video>
+  </div>
 </figure>
 
 Visit the [link](https://pursuit.page.link/MediaPipeHandTrackingSimd) in Chrome Canary with SIMD enabled to try it!
 
-Another interesting set of demos that makes use of SIMD for smooth experience, come from OpenCV - a popular computer vision library that can also be compiled to WebAssembly. They’re available by [link](https://bit.ly/opencv-camera-demos), or you can check out the pre-recorded versions below:
+Another interesting set of demos that makes use of SIMD for smooth experience come from OpenCV, a popular computer vision library that can also be compiled to WebAssembly. They’re available by [link](https://bit.ly/opencv-camera-demos), or you can check out the pre-recorded versions below:
 
 <figure>
-  <video autoplay muted playsinline loop src="/_img/simd/credit-card.mp4"></video>
+  <div class="video video-25:9">
+    <video autoplay muted playsinline loop width="256" height="512" src="/_img/simd/credit-card.mp4"></video>
+  </div>
   <figcaption>Card reading</figcaption>
 </figure>
 
 <figure>
-  <video autoplay muted playsinline loop src="/_img/simd/invisibility-cloak.mp4"></video>
+  <div class="video">
+    <video autoplay muted playsinline loop width="600" height="646" src="/_img/simd/invisibility-cloak.mp4"></video>
+  </div>
   <figcaption>Invisibility cloak</figcaption>
 </figure>
 
 <figure>
-  <video autoplay muted playsinline loop src="/_img/simd/emotion-recognizer.mp4"></video>
+  <div class="video">
+    <video autoplay muted playsinline loop width="600" height="658" src="/_img/simd/emotion-recognizer.mp4"></video>
+  </div>
   <figcaption>Emoji replacement</figcaption>
 </figure>
 


### PR DESCRIPTION
This makes sure that https://v8.dev/features/simd renders correctly on narrow viewports, but also that the embedded videos are responsive while maintaining their aspect ratio (similar to other videos on v8.dev, which previously were all YouTube embeds).

Closes #323.