### PR TITLE
Fix misplaced feature support header

### DIFF
--- a/src/features/function-tostring.md
+++ b/src/features/function-tostring.md
@@ -28,7 +28,7 @@ foo.toString();
 // → 'function /* comment */ foo () {}'
 ```
 
-## Optional `catch` binding support { #support }
+## Feature Support { #support }
 
 <feature-support chrome="66 /blog/v8-release-66#function-tostring"
                  firefox="yes"


### PR DESCRIPTION
The feature support header for https://v8.dev/features/function-tostring was incorrectly using the text from https://v8.dev/features/optional-catch-binding. This fixes it.