### PR TITLE
Add missing figcaption to a blog post

### DIFF
--- a/src/blog/understanding-ecmascript-part-1.md
+++ b/src/blog/understanding-ecmascript-part-1.md
@@ -232,7 +232,8 @@ Asserts in the spec assert invariant conditions of the algorithms. They are adde
 We have built the understanding needed for reading the spec for simple methods like `Object.prototype.hasOwnProperty` and abstract operations like `HasOwnProperty`. They still delegate to other abstract operations, but based on this blog post we should be able to figure out what they do. We’ll encounter Property Descriptors, which is just another specification type.
 
 <figure>
-  <img src="/_img/understanding-ecmascript-part-1/call-graph.svg" width="1082" height="306" alt="Function call graph starting from Object.prototype.hasOwnProperty">
+  <img src="/_img/understanding-ecmascript-part-1/call-graph.svg" width="1082" height="306" alt="" loading="lazy">
+  <figcaption>Function call graph starting from <code>Object.prototype.hasOwnProperty</code></figcaption>
 </figure>
 
 ## Useful links


### PR DESCRIPTION
Looks like this was an accidental omission as we use figcaption on all other images in the blog, but sending as a PR to double-check with the author.