### PR TITLE
Convert few more images with attributes

### DIFF
--- a/src/blog/code-caching-for-devs.md
+++ b/src/blog/code-caching-for-devs.md
@@ -48,9 +48,7 @@ In addition to passively doing nothing, you should also try your best to activel
 
 This may be obvious, but it’s worth making explicit — whenever you ship new code, that code is not yet cached. Whenever the browser makes an HTTP request for a script URL, it can include the date of the last fetch of that URL, and if the server knows that the file hasn’t changed, it can send back a 304 Not Modified response, which keeps our code cache hot. Otherwise, a 200 OK response updates our cached resource, and clears the code cache, reverting it back to a cold run.
 
-<figure>
-  <img src="/_img/code-caching-for-devs/http-200-vs-304.jpg" width="600" height="515" alt="" title="Drake prefers HTTP 304 responses to HTTP 200 responses." loading="lazy">
-</figure>
+![](/_img/code-caching-for-devs/http-200-vs-304.jpg "Drake prefers HTTP 304 responses to HTTP 200 responses.")
 
 It’s tempting to always push your latest code changes immediately, particularly if you want to measure the impact of a certain change, but for caches it’s much better to leave code be, or at least update it as rarely as possible. Consider imposing a limit of `≤ x` deployments per week, where `x` is the slider you can adjust to trade-off caching vs. staleness.
 
@@ -80,9 +78,7 @@ In this case, only `A()` or `B()` is compiled and executed on the warm run, and 
 
 Certainly the advice to do “nothing”, whether passively or actively, is not very satisfying. So in addition to doing “nothing”, given our current heuristics and implementation, there are some things you can do. Please remember, though, that heuristics can change, this advice may change, and there is no substitute for profiling.
 
-<figure>
-  <img src="/_img/code-caching-for-devs/with-great-power.jpg" width="500" height="209" alt="" title="Uncle Ben suggests that Peter Parker should be cautious when optimizing his web app’s cache behavior." loading="lazy">
-</figure>
+![](/_img/code-caching-for-devs/with-great-power.jpg "Uncle Ben suggests that Peter Parker should be cautious when optimizing his web app’s cache behavior.")
 
 ### Split out libraries from code using them { #split }
 

--- a/src/blog/cost-of-javascript-2019.md
+++ b/src/blog/cost-of-javascript-2019.md
@@ -181,10 +181,7 @@ The first pass can’t be avoided. Luckily, the second pass can be avoided by pl
 
 V8’s (byte)code-caching optimization can help. When a script is first requested, Chrome downloads it and gives it to V8 to compile. It also stores the file in the browser’s on-disk cache. When the JS file is requested a second time, Chrome takes the file from the browser cache and once again gives it to V8 to compile. This time, however, the compiled code is serialized, and is attached to the cached script file as metadata.
 
-<figure>
-  <img src="/_img/cost-of-javascript-2019/code-caching.png" srcset="/_img/cost-of-javascript-2019/code-caching@2x.png 2x" width="1431" height="774" alt="" loading="lazy" class="no-darkening">
-  <figcaption>Visualization of how code caching works in V8</figcaption>
-</figure>
+![Visualization of how code caching works in V8](/_img/cost-of-javascript-2019/code-caching.png){ .no-darkening }
 
 The third time, Chrome takes both the file and the file’s metadata from the cache, and hands both to V8. V8 deserializes the metadata and can skip compilation. Code caching kicks in if the first two visits happen within 72 hours. Chrome also has eager code caching if a service worker is used to cache scripts. You can read more about code caching in [code caching for web developers](/blog/code-caching-for-devs).
 

--- a/src/blog/v8-lite.md
+++ b/src/blog/v8-lite.md
@@ -41,9 +41,7 @@ In doing so, we determined that a significant portion of V8’s heap was dedicat
 
 As a result of this, we started work on a *Lite mode* of V8 that trades off speed of JavaScript execution against improved memory savings by vastly reducing the allocation of these optional objects.
 
-<figure>
-  <img src="/_img/v8-lite/v8-lite.png" width="149" height="231" alt="" loading="lazy" class="no-darkening">
-</figure>
+![](/_img/v8-lite/v8-lite.png){ .no-darkening }
 
 A number of the *Lite mode* changes could be made by configuring existing V8 settings, for example, disabling V8’s TurboFan optimizing compiler. However, others required more involved changes to V8.
 


### PR DESCRIPTION
Follow-up to #354. 

Unfortunately, overriding width or height via markdown-it-attrs syntax is not yet possible due to conflicts between plugins and undocumented APIs, but at least we can convert few more images meanwhile.