### PR TITLE
Revert "Add syntax highlighting support for numeric separators"

### DIFF
--- a/prism-languages.js
+++ b/prism-languages.js
@@ -13,11 +13,6 @@
 
 const installPrismLanguages = (Prism) => {
 
-  // Add support for numeric separators.
-  // TODO: Remove this once a `prism-js` version containing
-  // https://github.com/PrismJS/prism/pull/1895 is released.
-  Prism.languages.javascript.number = /\b(?:(?:0[xX](?:[\dA-Fa-f](?:_[\dA-Fa-f])?)+|0[bB](?:[01](?:_[01])?)+|0[oO](?:[0-7](?:_[0-7])?)+)n?|(?:\d(?:_\d)?)+n|NaN|Infinity)\b|(?:\b(?:\d(?:_\d)?)+\.?(?:\d(?:_\d)?)*|\B\.(?:\d(?:_\d)?)+)(?:[Ee][+-]?(?:\d(?:_\d)?)+)?/;
-
   // Based on the grammar defined at the bottom of:
   // https://cs.chromium.org/chromium/src/v8/src/torque/torque-parser.cc
   Prism.languages.torque = {


### PR DESCRIPTION

A new version of PrismJS with native support has been since released.

This reverts commit 50078bd57e65809d0f33c1522a4458cef41c14e0.