### PR TITLE
Upgrade markdown-it-implicit-figures

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "markdown-it-attrs": "^3.0.1",
     "markdown-it-container": "^2.0.0",
     "markdown-it-footnote": "^3.0.2",
-    "markdown-it-implicit-figures": "RReverser/markdown-it-implicit-figures#fix-img-alt",
+    "markdown-it-implicit-figures": "^0.10.0",
     "markdown-it-multimd-table": "^4.0.0",
     "markdownlint-cli": "^0.22.0",
     "minify-xml": "^1.0.3",


### PR DESCRIPTION

My fix (https://github.com/arve0/markdown-it-implicit-figures/pull/34) has been merged and released, so change markdown-it-implicit-figures back from fork to the upstream.