### PR TITLE
Optional chaining support available in Firefox 74

### DIFF
--- a/src/features/optional-chaining.md
+++ b/src/features/optional-chaining.md
@@ -134,7 +134,7 @@ More details can be found in [the _Semantics_ section of the proposal](https://g
 ## Support for optional chaining { #support }
 
 <feature-support chrome="80 https://bugs.chromium.org/p/v8/issues/detail?id=9553"
-                 firefox="no https://bugzilla.mozilla.org/show_bug.cgi?id=1566143"
+                 firefox="74 https://bugzilla.mozilla.org/show_bug.cgi?id=1566143"
                  safari="no https://bugs.webkit.org/show_bug.cgi?id=200199"
                  nodejs="14 https://medium.com/@nodejs/node-js-version-14-available-now-8170d384567e"
                  babel="yes https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining"></feature-support>


### PR DESCRIPTION
This awesome language feature is now available in Firefox. Let's update the support table to let developers know the good news!

See release notes at Mozilla:
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/74#JavaScript