### PR TITLE
Add a comment about tags in the node-integration doc

### DIFF
--- a/src/docs/node-integration.md
+++ b/src/docs/node-integration.md
@@ -53,6 +53,8 @@ Make your changes to the Node.js checkout, and commit them. Then push the change
 **Note:** `<sync-date>` is the date we sync’ed with upstream Node.js. Choose the latest date.
 :::
 
+If your changes need to be eventually upstreamed, please add the tag `upstream` with the supported V8 version, e.g. `[upstream:v8.4.377]`. If your changes are temporary (it disables for example a test), please add the tag `temp` and the version of V8 in which the changes should be discarded, e.g., `[temp:v8.4.377]`.
+
 ```bash
 git push <your-user-name> make-changes
 ```


### PR DESCRIPTION
Every time we update our Node fork, we rebase the repo with our floating patches. These floating patches usually don't do much, they are either a quick fix to make a CL succeed the node-ci bot, or they should be upstreamed and removed when rebasing/updating.

I have recently removed many of these old patches: https://github.com/v8/node/commits/node-ci-2020-05-11

It would be nice if every patch had a tag indicating if it must be removed or upstreamed.