### PR TITLE
Update <dark-mode-toggle> version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@browser-logos/safari": "^1.0.4",
     "autoprefixer": "^9.6.1",
     "cssnano": "^4.1.10",
-    "dark-mode-toggle": "^0.5.1",
+    "dark-mode-toggle": "^0.6.0",
     "firebase-tools": "^7.2.4",
     "get-video-dimensions": "^1.0.0",
     "glob": "^7.1.4",


### PR DESCRIPTION
`no-preference` was removed from the spec, so the toggle needs to no longer deal with it, which makes the code size smaller. 🎉