### PR TITLE
Add note to add blink CQ bot when shipping wasm features

### DIFF
--- a/src/docs/wasm-shipping-checklist.md
+++ b/src/docs/wasm-shipping-checklist.md
@@ -43,6 +43,7 @@ See the [staging of type reflection](https://crrev.com/c/1771791) as a reference
 
 ## How to ship a WebAssembly Feature
 
-- In [`src/wasm/wasm-feature-flags.h`](https://cs.chromium.org/chromium/src/v8/src/wasm/wasm-feature-flags.h), move the feature flag from the `FOREACH_WASM_STAGING_FEATURE_FLAG` macro list to the `FOREACH_WASM_SHIPPED_FEATURE_FLAG` macro list.
+- In [`src/wasm/wasm-feature-flags.h`](https://source.chromium.org/chromium/chromium/src/+/master:v8/src/wasm/wasm-feature-flags.h), move the feature flag from the `FOREACH_WASM_STAGING_FEATURE_FLAG` macro list to the `FOREACH_WASM_SHIPPED_FEATURE_FLAG` macro list.
+  - Ensure to add a blink CQ bot on the CL to check for [blink web test](https://v8.dev/docs/blink-layout-tests) failures caused by enabling the feature.
 - Additionally, enable the feature by default by changing the third parameter in `FOREACH_WASM_SHIPPED_FEATURE_FLAG` to `true`.
 - Set a reminder to remove the feature flag after two milestones.

--- a/src/docs/wasm-shipping-checklist.md
+++ b/src/docs/wasm-shipping-checklist.md
@@ -44,6 +44,6 @@ See the [staging of type reflection](https://crrev.com/c/1771791) as a reference
 ## How to ship a WebAssembly Feature
 
 - In [`src/wasm/wasm-feature-flags.h`](https://source.chromium.org/chromium/chromium/src/+/master:v8/src/wasm/wasm-feature-flags.h), move the feature flag from the `FOREACH_WASM_STAGING_FEATURE_FLAG` macro list to the `FOREACH_WASM_SHIPPED_FEATURE_FLAG` macro list.
-    - Ensure to add a blink CQ bot on the CL to check for [blink web test](https://v8.dev/docs/blink-layout-tests) failures caused by enabling the feature.
+    - Ensure to add a blink CQ bot on the CL to check for [blink web test](https://v8.dev/docs/blink-layout-tests) failures caused by enabling the feature (add this line to the footer of the CL description: `Cq-Include-Trybots: luci.v8.try:v8_linux_blink_rel`).
 - Additionally, enable the feature by default by changing the third parameter in `FOREACH_WASM_SHIPPED_FEATURE_FLAG` to `true`.
 - Set a reminder to remove the feature flag after two milestones.

--- a/src/docs/wasm-shipping-checklist.md
+++ b/src/docs/wasm-shipping-checklist.md
@@ -44,6 +44,6 @@ See the [staging of type reflection](https://crrev.com/c/1771791) as a reference
 ## How to ship a WebAssembly Feature
 
 - In [`src/wasm/wasm-feature-flags.h`](https://source.chromium.org/chromium/chromium/src/+/master:v8/src/wasm/wasm-feature-flags.h), move the feature flag from the `FOREACH_WASM_STAGING_FEATURE_FLAG` macro list to the `FOREACH_WASM_SHIPPED_FEATURE_FLAG` macro list.
-  - Ensure to add a blink CQ bot on the CL to check for [blink web test](https://v8.dev/docs/blink-layout-tests) failures caused by enabling the feature.
+    - Ensure to add a blink CQ bot on the CL to check for [blink web test](https://v8.dev/docs/blink-layout-tests) failures caused by enabling the feature.
 - Additionally, enable the feature by default by changing the third parameter in `FOREACH_WASM_SHIPPED_FEATURE_FLAG` to `true`.
 - Set a reminder to remove the feature flag after two milestones.


### PR DESCRIPTION
With the last two features we shipped, we accidentally broke the blink web tests, causing a delay in the v8 roll.
This adds a note to the shipping document to hopefully avoid this in the future.

Drive-by: Update the link to the `wasm-feature-flags.h` file (it will redirect there anyway).