### PR TITLE
Add redirect rule

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -62,6 +62,11 @@
         "source": "/tools",
         "destination": "https://v8.github.io/tools/head/",
         "type": 301
+      },
+      {
+        "regex": "/tools/(?P<version>v[0-9]+.*)",
+        "destination": "https\://v8.github.io/tools/:version",
+        "type": 301
       }
     ],
     "headers": [

--- a/firebase.json
+++ b/firebase.json
@@ -65,7 +65,7 @@
       },
       {
         "regex": "/tools/(?P<version>v[0-9]+.*)",
-        "destination": "https\://v8.github.io/tools/:version",
+        "destination": "//v8.github.io/tools/:version",
         "type": 301
       }
     ],


### PR DESCRIPTION
Avoiding the colon by omitting `http:` might help with the regexp redirect pattern issues.