### PR TITLE
Fixed overflow on narrow viewports issue #378

### DIFF
--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -475,7 +475,7 @@ dark-mode-toggle {
 
 @media (max-width: 770px) {
   :root {
-    --offset: 10px;
+    --offset: 12px;
   }
   body {
     padding: 0;


### PR DESCRIPTION
List numbers overflow on mobile devices #378

Hey, this is how it will look, fixing the overflow issue:
<img width="704" alt="Screenshot 2020-06-28 at 11 18 32 PM" src="https://user-images.githubusercontent.com/20089340/85954922-95f12d80-b998-11ea-82ab-471a40154818.png">


But if I make it 14px it will look like this:

<img width="891" alt="Screenshot 2020-06-28 at 11 26 56 PM" src="https://user-images.githubusercontent.com/20089340/85954934-aef9de80-b998-11ea-9dbd-479a40f5b327.png">

Should I make it 13/14px for a better style?