### PR TITLE
Update firebase tools and add regex redirects

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -59,13 +59,13 @@
         "type": 301
       },
       {
-        "source": "/tools",
-        "destination": "https://v8.github.io/tools/head/",
+        "regex": "/tools/(?P<version>v[0-9]+.*)",
+        "destination": "//v8.github.io/tools/:version",
         "type": 301
       },
       {
-        "regex": "/tools/(?P<version>v[0-9]+.*)",
-        "destination": "//v8.github.io/tools/:version",
+        "source": "/tools/:tool*",
+        "destination": "https://v8.github.io/tools/head/:tool",
         "type": 301
       }
     ],

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "autoprefixer": "^9.8.2",
     "cssnano": "^4.1.10",
     "dark-mode-toggle": "^0.6.0",
-    "firebase-tools": "^8.4.3",
+    "firebase-tools": "^8.5.0",
     "get-video-dimensions": "^1.0.0",
     "glob": "^7.1.6",
     "he": "^1.2.0",


### PR DESCRIPTION
- Update firebase-tools to v8.5.0
- Add regex-based redirects for v8 tools