### PR TITLE
Add page about respectful code

### DIFF
--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -25,6 +25,7 @@ V8 enables any C++ application to expose its own objects and functions to JavaSc
     - [Cross-compiling for iOS](/docs/cross-compile-ios)
     - [GUI and IDE setup](/docs/ide-setup)
 - [Contributing](/docs/contribute)
+    - [Respectful code](/docs/respectful-code)
     - [V8’s public API and its stability](/docs/api)
     - [Becoming a V8 committer](/docs/become-committer)
     - [Committer’s responsibility](/docs/committer-responsibility)

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -1,6 +1,6 @@
 ---
-title: 'Respectful code'
-description: 'Inclusivity is central to V8's culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination.'
+title: "Respectful code"
+description: "Inclusivity is central to V8’s culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination."
 ---
 
 Inclusivity is central to V8's culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination. However, terms in our codebase, UIs, and documentation can perpetuate that discrimination. This document sets forth guidance which aims to address disrespectful terminology in code and documentation.

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -3,7 +3,7 @@ title: "Respectful code"
 description: "Inclusivity is central to V8’s culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination."
 ---
 
-Inclusivity is central to V8's culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination. However, terms in our codebase, UIs, and documentation can perpetuate that discrimination. This document sets forth guidance which aims to address disrespectful terminology in code and documentation.
+Inclusivity is central to V8’s culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination. However, terms in our codebase, UIs, and documentation can perpetuate that discrimination. This document sets forth guidance which aims to address disrespectful terminology in code and documentation.
 
 ## Policy
 

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -5,7 +5,7 @@ description: "Inclusivity is central to V8’s culture, and our values include t
 
 Inclusivity is central to V8’s culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination. However, terms in our codebase, UIs, and documentation can perpetuate that discrimination. This document sets forth guidance which aims to address disrespectful terminology in code and documentation.
 
-## Policy
+## Policy { #policy }
 
 Terminology that is derogatory, hurtful, or perpetuates discrimination, either directly or indirectly, should be avoided.
 

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -21,8 +21,8 @@ Anything that a contributor would read while working on V8, including:
 
 ## Principles
 
-- Be respectful: Derogatory language shouldn’t be necessary to describe how things work.
-- Respect culturally sensitive language: Some words may carry significant historical or political meanings. Please be mindful of this and use alternatives.
+- Be respectful: derogatory language shouldn’t be necessary to describe how things work.
+- Respect culturally sensitive language: some words may carry significant historical or political meanings. Please be mindful of this and use alternatives.
 
 ## How do I know if particular terminology is OK or not?
 

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -9,7 +9,7 @@ Inclusivity is central to V8’s culture, and our values include treating each o
 
 Terminology that is derogatory, hurtful, or perpetuates discrimination, either directly or indirectly, should be avoided.
 
-## What is in scope for this policy?
+## What is in scope for this policy? { #scope }
 
 Anything that a contributor would read while working on V8, including:
 

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -26,7 +26,7 @@ Anything that a contributor would read while working on V8, including:
 
 ## How do I know if particular terminology is OK or not?
 
-Apply the principles above. If you have any questions, you can reach out to ???@google.com.
+Apply the principles above. If you have any questions, you can reach out to `v8-dev@googlegroups.com`.
 
 ## What are examples of terminology to be avoided?
 

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -43,6 +43,7 @@ This list is NOT meant to be comprehensive. It contains a few examples that peop
 | sane      | expected, appropriate, sensible, valid                        |
 | crazy     | unexpected, catastrophic, incoherent                          |
 | redline   | priority line, limit, soft limit                              |
+:::
 
 ## What if I am interfacing with something that violates this policy? { #violations }
 

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -32,6 +32,7 @@ Apply the principles above. If you have any questions, you can reach out to `v8-
 
 This list is NOT meant to be comprehensive. It contains a few examples that people have run into frequently.
 
+:::table-wrapper
 | Term      | Suggested alternatives                                        |
 | --------- | ------------------------------------------------------------- |
 | master    | primary, controller, leader, host                             |

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -47,5 +47,5 @@ This list is NOT meant to be comprehensive. It contains a few examples that peop
 
 This circumstance has come up a few times, particularly for code implementing specifications. In these circumstances, differing from the language in the specification may interfere with the ability to understand the implementation. For these circumstances, we suggest one of the following, in order of decreasing preference:
 
-1. If using alternate terminology doesn't interfere with understanding, use alternate terminology.
+1. If using alternate terminology doesn’t interfere with understanding, use alternate terminology.
 2. Failing that, do not propagate the terminology beyond the layer of code that is performing the interfacing. Where necessary, use alternative terminology at the API boundaries.

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -1,6 +1,6 @@
 ---
-title: "Respectful code"
-description: "Inclusivity is central to V8’s culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination."
+title: 'Respectful code'
+description: 'Inclusivity is central to V8’s culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination.'
 ---
 
 Inclusivity is central to V8’s culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination. However, terms in our codebase, UIs, and documentation can perpetuate that discrimination. This document sets forth guidance which aims to address disrespectful terminology in code and documentation.

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -19,16 +19,16 @@ Anything that a contributor would read while working on V8, including:
 - Documentation (both inside and outside of source files)
 - Commit messages
 
-## Principles
+## Principles { #principles }
 
 - Be respectful: derogatory language shouldn’t be necessary to describe how things work.
 - Respect culturally sensitive language: some words may carry significant historical or political meanings. Please be mindful of this and use alternatives.
 
-## How do I know if particular terminology is OK or not?
+## How do I know if particular terminology is OK or not? { #questions }
 
 Apply the principles above. If you have any questions, you can reach out to `v8-dev@googlegroups.com`.
 
-## What are examples of terminology to be avoided?
+## What are examples of terminology to be avoided? { #examples }
 
 This list is NOT meant to be comprehensive. It contains a few examples that people have run into frequently.
 
@@ -43,7 +43,7 @@ This list is NOT meant to be comprehensive. It contains a few examples that peop
 | crazy     | unexpected, catastrophic, incoherent                          |
 | redline   | priority line, limit, soft limit                              |
 
-## What if I am interfacing with something that violates this policy?
+## What if I am interfacing with something that violates this policy? { #violations }
 
 This circumstance has come up a few times, particularly for code implementing specifications. In these circumstances, differing from the language in the specification may interfere with the ability to understand the implementation. For these circumstances, we suggest one of the following, in order of decreasing preference:
 

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -1,0 +1,51 @@
+---
+title: 'Respectful code'
+description: 'Inclusivity is central to V8's culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination.'
+---
+
+Inclusivity is central to V8's culture, and our values include treating each other with dignity. As such, it’s important that everyone can contribute without facing the harmful effects of bias and discrimination. However, terms in our codebase, UIs, and documentation can perpetuate that discrimination. This document sets forth guidance which aims to address disrespectful terminology in code and documentation.
+
+## Policy
+
+Terminology that is derogatory, hurtful, or perpetuates discrimination, either directly or indirectly, should be avoided.
+
+## What is in scope for this policy?
+
+Anything that a contributor would read while working on V8, including:
+
+- Names of variables, types, functions, files, build rules, binaries, exported variables, ...
+- Test data
+- System output and displays
+- Documentation (both inside and outside of source files)
+- Commit messages
+
+## Principles
+
+- Be respectful: Derogatory language shouldn’t be necessary to describe how things work.
+- Respect culturally sensitive language: Some words may carry significant historical or political meanings. Please be mindful of this and use alternatives.
+
+## How do I know if particular terminology is OK or not?
+
+Apply the principles above. If you have any questions, you can reach out to ???@google.com.
+
+## What are examples of terminology to be avoided?
+
+This list is NOT meant to be comprehensive. It contains a few examples that people have run into frequently.
+
+| Term      | Suggested alternatives                                        |
+| --------- | ------------------------------------------------------------- |
+| master    | primary, controller, leader, host                             |
+| slave     | replica, subordinate, secondary, follower, device, peripheral |
+| whitelist | allowlist, exception list, inclusion list                     |
+| blacklist | denylist, blocklist, exclusion list                           |
+| insane    | unexpected, catastrophic, incoherent                          |
+| sane      | expected, appropriate, sensible, valid                        |
+| crazy     | unexpected, catastrophic, incoherent                          |
+| redline   | priority line, limit, soft limit                              |
+
+## What if I am interfacing with something that violates this policy?
+
+This circumstance has come up a few times, particularly for code implementing specifications. In these circumstances, differing from the language in the specification may interfere with the ability to understand the implementation. For these circumstances, we suggest one of the following, in order of decreasing preference:
+
+1. If using alternate terminology doesn't interfere with understanding, use alternate terminology.
+2. Failing that, do not propagate the terminology beyond the layer of code that is performing the interfacing. Where necessary, use alternative terminology at the API boundaries.

--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -48,4 +48,4 @@ This list is NOT meant to be comprehensive. It contains a few examples that peop
 This circumstance has come up a few times, particularly for code implementing specifications. In these circumstances, differing from the language in the specification may interfere with the ability to understand the implementation. For these circumstances, we suggest one of the following, in order of decreasing preference:
 
 1. If using alternate terminology doesn’t interfere with understanding, use alternate terminology.
-2. Failing that, do not propagate the terminology beyond the layer of code that is performing the interfacing. Where necessary, use alternative terminology at the API boundaries.
+1. Failing that, do not propagate the terminology beyond the layer of code that is performing the interfacing. Where necessary, use alternative terminology at the API boundaries.


### PR DESCRIPTION
Added a “Respectful Code” chapter to the “Contributing” section under “Docs”. 