### PR TITLE
Preload dark mode toggle code

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="color-scheme" content="dark light">
     <link rel="stylesheet" href="/_css/main.css">
+    <link rel="modulepreload" href="/_js/dark-mode-toggle.mjs">
 {% if '/features' in page.url %}
     <link rel="stylesheet" href="/_css/feature-support.css">
 {% endif %}

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="color-scheme" content="dark light">
     <link rel="stylesheet" href="/_css/main.css">
-    <link rel="modulepreload" href="/_js/dark-mode-toggle.mjs">
 {% if '/features' in page.url %}
     <link rel="stylesheet" href="/_css/feature-support.css">
 {% endif %}
@@ -49,6 +48,7 @@
       </div>
       <p><small>Except as otherwise noted, any code samples from the V8 project are licensed under <a href="https://chromium.googlesource.com/v8/v8.git/+/master/LICENSE">V8’s BSD-style license</a>. Other content on this page is licensed under <a href="https://creativecommons.org/licenses/by/3.0/">the Creative Commons Attribution 3.0 License</a>. For details, see <a href="/terms#site-policies">our site policies</a>.</small></p>
     </footer>
+    <script type="module" src="/_js/dark-mode-toggle.mjs"></script>
     <script type="module" src="/_js/main.mjs"></script>
     <script nomodule src="/_js/legacy.js"></script>
   </body>

--- a/src/_js/main.mjs
+++ b/src/_js/main.mjs
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import '/_js/dark-mode-toggle.mjs';
-
 const darkModeToggle = document.querySelector('dark-mode-toggle');
 
 // Only load the Twitter script when we need it.


### PR DESCRIPTION
The code for the `<dark-mode-toggle>` is discovered too late (see last row in screenshot below), causing flash of white:

<img width="688" alt="Screen Shot 2020-07-29 at 10 59 51" src="https://user-images.githubusercontent.com/145676/88780170-e40d7280-d18a-11ea-8ae2-05db7e8dd60a.png">

This PR preloads the code. Fixes https://github.com/v8/v8.dev/issues/335 (at least improves the situation).
