### PR TITLE
Update information on using perf

### DIFF
--- a/src/docs/linux-perf.md
+++ b/src/docs/linux-perf.md
@@ -4,12 +4,12 @@ description: 'This document explains how to analyze the performance of V8’s JI
 ---
 V8 has built-in support for the Linux `perf` tool. By default, this support is disabled, but by using the `--perf-prof` and `--perf-prof-debug-info` command-line options, V8 writes out performance data during execution into a file that can be used to analyze the performance of V8’s JITted code with the Linux `perf` tool.
 
-## Setup
+## Optional: Get recent kernel and `perf`
 
 In order to analyze V8 JIT code with the Linux `perf` tool, you need to:
 
-- Use a very recent Linux kernel that provides high-resolution timing information to the `perf` tool and to V8’s `perf` integration in order to synchronize JIT code performance samples with the standard performance data collected by the Linux `perf` tool.
-- Use a recent very recent version of the Linux `perf` tool or apply the patch that supports JIT code to `perf` and build it yourself.
+- Use a recent Linux kernel that provides high-resolution timing information to the `perf` tool and to V8’s `perf` integration in order to synchronize JIT code performance samples with the standard performance data collected by the Linux `perf` tool.
+- Use a recent version of the Linux `perf` tool or apply the patch that supports JIT code to `perf` and build it yourself.
 
 Install a new Linux kernel, and then reboot your machine:
 
@@ -33,7 +33,9 @@ cd tip/tools/perf
 make
 ```
 
-## Build
+In the following steps, invoke `perf` as `<path_to_kernel_checkout>/tip/tools/perf/perf`.
+
+## Build V8
 
 To use V8’s integration with Linux perf you need to build it with the appropriate GN build flag activated. You can set `enable_profiling = true` in an existing GN build configuration.
 
@@ -46,9 +48,8 @@ Alternatively, you create a new clean build configuration with only the single b
 
 ```bash
 cd <path_to_your_v8_checkout>
-tools/dev/v8gen.py x64.release
-echo 'enable_profiling = true' >> out.gn/x64.release/args.gn
-ninja -C out.gn/x64.release
+gn gen out/x64.release --args='is_debug=false target_cpu="x64" enable_profiling=true'
+ninja -C out/x64.release
 ```
 
 ## Running `d8` with perf flags
@@ -60,9 +61,8 @@ cd <path_to_your_v8_checkout>
 echo '(function f() {
     var s = 0; for (var i = 0; i < 1000000000; i++) { s += i; } return s;
   })();' > test.js
-<path_to_kernel_checkout>/tip/tools/perf/perf record -k mono \
-    out.gn/x64.release/d8 --perf-prof --nowrite-protect-code-memory \
-    test.js
+perf record -k mono out/x64.release/d8 \
+    --perf-prof --no-write-protect-code-memory test.js
 ```
 
 ## Evaluating perf output
@@ -70,12 +70,11 @@ echo '(function f() {
 After execution finishes, you must combine the static information gathered from the `perf` tool with the performance samples output by V8 for JIT code:
 
 ```bash
-<path_to_kernel_checkout>/tip/tools/perf/perf inject -j -i perf.data \
-    -o perf.data.jitted
+perf inject -j -i perf.data -o perf.data.jitted
 ```
 
 Finally you can use the Linux `perf` tool to explore the performance bottlenecks in your JITted code:
 
 ```bash
-<path_to_kernel_checkout>/tip/tools/perf/perf report -i perf.data.jitted
+perf report -i perf.data.jitted
 ```


### PR DESCRIPTION
The standard installed kernel and perf tool are often good enough, so mark the
respective section optional. Also, use gn directly instead of the v8gen.py tool.