### PR TITLE
Remove unneeded routing rule (#464)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -88,13 +88,6 @@
         }]
       },
       {
-        "source": "**/*.@(js|mjs)",
-        "headers": [{
-          "key": "Content-Type",
-          "value": "text/javascript;charset=utf-8"
-        }]
-      },
-      {
         "source": "/*.atom",
         "headers": [{
           "key": "Content-Type",


### PR DESCRIPTION
This pull request fixes the issue proved at #464 where a URL ending with `.js` (in the case for `/tags/Node.js`) wouldn't render a html but a javascript page. 

I've removed the rule in `firebase.json` that forces the header of all files under the `**/*.@(js|mjs)` pattern. Removing the rule delegates the routing to the defaults defined by `superstatic`.

I've tested this fix quickly by navigating around and checking the headers from the browser inspector which seem to be correct. Please let me know if it works.