### PR TITLE
Fix api and tools redirects

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -14,13 +14,18 @@
         "type": 302
       },
       {
-        "regex": "/api/(?P<api>v[0-9]+.*)",
-        "destination": "https://v8.github.io/api/:api",
+        "source": "/api/v:version*",
+        "destination": "https://v8.github.io/api/v:version",
         "type": 301
       },
       {
-        "regex": "/api(?P<api>(/.*)?)",
-        "destination": "https://v8.github.io/api/head:api",
+        "source": "/api",
+        "destination": "https://v8.github.io/api/head",
+        "type": 301
+      },
+      {
+        "source": "/api/:api*",
+        "destination": "https://v8.github.io/api/head/:api",
         "type": 301
       },
       {
@@ -59,17 +64,17 @@
         "type": 301
       },
       {
-        "regex": "/tools/(?P<tool>v[0-9]+.*)",
-        "destination": "https://v8.github.io/tools/:tool",
-        "type": 301
-      },
-      {
         "source": "/tools/versions",
         "destination": "https://v8.github.io/tools/",
         "type": 301
       },
       {
-        "regex": "/tools(?P<tool>(/.*)?)",
+        "source": "/tools/v:tool*",
+        "destination": "https://v8.github.io/tools/v:tool",
+        "type": 301
+      },
+      {
+        "source": "/tools/:tool",
         "destination": "https://v8.github.io/tools/head:tool",
         "type": 301
       },

--- a/firebase.json
+++ b/firebase.json
@@ -14,18 +14,13 @@
         "type": 302
       },
       {
-        "source": "/api/v:version*",
-        "destination": "https://v8.github.io/api/v:version",
-        "type": 301
-      },
-      {
         "source": "/api",
         "destination": "https://v8.github.io/api/head",
         "type": 301
       },
       {
         "source": "/api/:api*",
-        "destination": "https://v8.github.io/api/head/:api",
+        "destination": "https://v8.github.io/api/:api",
         "type": 301
       },
       {
@@ -64,18 +59,18 @@
         "type": 301
       },
       {
+        "source": "/tools",
+        "destination": "https://v8.github.io/tools/head",
+        "type": 301
+      },
+      {
         "source": "/tools/versions",
         "destination": "https://v8.github.io/tools/",
         "type": 301
       },
       {
-        "source": "/tools/v:tool*",
-        "destination": "https://v8.github.io/tools/v:tool",
-        "type": 301
-      },
-      {
         "source": "/tools/:tool",
-        "destination": "https://v8.github.io/tools/head:tool",
+        "destination": "https://v8.github.io/tools/:tool",
         "type": 301
       },
     ],

--- a/firebase.json
+++ b/firebase.json
@@ -14,12 +14,12 @@
         "type": 302
       },
       {
-        "regex": "/api/(?P<version_api>v[0-9]+.*)",
-        "destination": "https://v8.github.io/api/:version_api",
+        "regex": "/api/(?P<api>v[0-9]+.*)",
+        "destination": "https://v8.github.io/api/:api",
         "type": 301
       },
       {
-        "regex": "/api(?P<api>/.*)",
+        "regex": "/api(?P<api>(/.*)?)",
         "destination": "https://v8.github.io/api/head:api",
         "type": 301
       },
@@ -59,13 +59,8 @@
         "type": 301
       },
       {
-        "regex": "/tools/(?P<version_tool>v[0-9]+.*)",
-        "destination": "https://v8.github.io/tools/:version_tool",
-        "type": 301
-      },
-      {
-        "source": "/tools",
-        "destination": "https://v8.github.io/tools/head",
+        "regex": "/tools/(?P<tool>v[0-9]+.*)",
+        "destination": "https://v8.github.io/tools/:tool",
         "type": 301
       },
       {
@@ -74,10 +69,10 @@
         "type": 301
       },
       {
-        "source": "/tools/:tool*",
-        "destination": "https://v8.github.io/tools/head/:tool",
+        "regex": "/tools(?P<tool>(/.*)?)",
+        "destination": "https://v8.github.io/tools/head:tool",
         "type": 301
-      }
+      },
     ],
     "headers": [
       {

--- a/firebase.json
+++ b/firebase.json
@@ -72,7 +72,7 @@
         "source": "/tools/:tool",
         "destination": "https://v8.github.io/tools/:tool",
         "type": 301
-      },
+      }
     ],
     "headers": [
       {

--- a/src/blog/system-analyzer.md
+++ b/src/blog/system-analyzer.md
@@ -12,11 +12,11 @@ tweet: '1311689392608731140'
 ---
 # Indicium: V8 system analyzer
 
-The past three months have been an awesome learning experience for me as I've joined the V8 team (Google London) as an intern, and have been working on a new tool called [*Indicium*](https://v8.dev/tools/system-analyzer).
+The past three months have been an awesome learning experience for me as I've joined the V8 team (Google London) as an intern, and have been working on a new tool called [*Indicium*](https://v8.dev/tools/head/system-analyzer).
 
 This system analyzer is a unified web interface to trace, debug and analyse patterns of how Inline Caches (ICs) and Maps are created and modified in real-world applications.
 
-V8 already has a tracing infrastructure for [ICs](https://mathiasbynens.be/notes/shapes-ics) and [Maps](https://v8.dev/blog/fast-properties) which can process and analyse IC events using the [IC Explorer](https://v8.dev/tools//ic-explorer.html) and Map events using [Map Processor](https://v8.dev/tools/map-processor.html). However, previous tools didn't allow us to analyze maps and ICs holistically and this is now possible with system analyzer.
+V8 already has a tracing infrastructure for [ICs](https://mathiasbynens.be/notes/shapes-ics) and [Maps](https://v8.dev/blog/fast-properties) which can process and analyse IC events using the [IC Explorer](https://v8.dev/tools/v8.8/ic-explorer.html) and Map events using [Map Processor](https://v8.dev/tools/v8.8/map-processor.html). However, previous tools didn't allow us to analyze maps and ICs holistically and this is now possible with system analyzer.
 
 ![Indicium](/_img/system-analyzer/indicium-logo.png)
 

--- a/src/blog/system-analyzer.md
+++ b/src/blog/system-analyzer.md
@@ -16,7 +16,7 @@ The past three months have been an awesome learning experience for me as I've jo
 
 This system analyzer is a unified web interface to trace, debug and analyse patterns of how Inline Caches (ICs) and Maps are created and modified in real-world applications.
 
-V8 already has a tracing infrastructure for [ICs](https://mathiasbynens.be/notes/shapes-ics) and [Maps](https://v8.dev/blog/fast-properties) which can process and analyse IC events using the [IC Explorer](https://v8.dev/tools/v8.8/ic-explorer.html) and Map events using [Map Processor](https://v8.dev/tools/v8.8/map-processor.html). However, previous tools didn't allow us to analyze maps and ICs holistically and this is now possible with system analyzer.
+V8 already has a tracing infrastructure for [ICs](https://mathiasbynens.be/notes/shapes-ics) and [Maps](https://v8.dev/blog/fast-properties) which can process and analyse IC events using the [IC Explorer](https://v8.dev/tools/v8.7/ic-explorer.html) and Map events using [Map Processor](https://v8.dev/tools/v8.7/map-processor.html). However, previous tools didn't allow us to analyze maps and ICs holistically and this is now possible with system analyzer.
 
 ![Indicium](/_img/system-analyzer/indicium-logo.png)
 


### PR DESCRIPTION
Simplify v8.dev/tools and v8.dev/api redirects

- Always include version (vX.Y or head) in tools and api links
- Remove complex regexp redirects