### PR TITLE
Configure AVIF MIME type for Firebase hosting

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -133,7 +133,16 @@
         ]
       },
       {
-        "source": "**/*.@(jpg|gif|png|svg|ico|webmanifest)",
+        "source": "**/*.avif",
+        "headers": [
+          {
+            "key": "Content-Type",
+            "value": "image/avif"
+          }
+        ]
+      },
+      {
+        "source": "**/*.@(jpg|gif|png|webp|avif|svg|ico|webmanifest)",
         "headers": [
           {
             "key": "Cache-Control",


### PR DESCRIPTION
This makes it so that AVIF images still work when requested directly, e.g.

    https://v8.dev/_img/avatars/ingvar-stepanyan.avif

…currently has `Content-Type: text/html`. Luckily this hasn’t been a problem
for displaying these images within HTML documents.