### PR TITLE
Remove AVIF MIME type special-casing

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -133,15 +133,6 @@
         ]
       },
       {
-        "source": "**/*.avif",
-        "headers": [
-          {
-            "key": "Content-Type",
-            "value": "image/avif"
-          }
-        ]
-      },
-      {
         "source": "**/*.@(jpg|gif|png|webp|avif|svg|ico|webmanifest)",
         "headers": [
           {


### PR DESCRIPTION
Once Firebase Hosting includes AVIF MIME types in its default configuration, we no longer need to manually configure this. 

We can check the preview URL to see when this change is live.
https://v8-dev--pr506-remove-avif-mime-jiyhb8rw.web.app/_img/avatars/ingvar-stepanyan.avif