### PR TITLE
Fix typos

### DIFF
--- a/src/docs/benchmarks.md
+++ b/src/docs/benchmarks.md
@@ -103,7 +103,7 @@ Wrote /usr/local/google/home/mvstanton/src/v8/_results/master.
 Run octane again with compare mode to see results.
 ```
 
-Note the warning that one run usually isn’t enough to be sure of many performance optimizations, however, our “change” should have a reproducable effect with only one run! Now let’s compare, passing the `--noopt` flag to turn off [TurboFan](/docs/turbofan):
+Note the warning that one run usually isn’t enough to be sure of many performance optimizations, however, our “change” should have a reproducible effect with only one run! Now let’s compare, passing the `--noopt` flag to turn off [TurboFan](/docs/turbofan):
 
 ```bash
 $ test/benchmarks/csuite/csuite.py -r 1 octane compare out.gn/x64.release/d8 \

--- a/src/docs/profile-chromium.md
+++ b/src/docs/profile-chromium.md
@@ -33,14 +33,14 @@ Please note that you wouldn’t see profiles in Developer Tools, because all the
 
 `--js-flags` contains the flags passed to V8:
 
-- `--logfile=%t.log` specifies a name pattern for log files. `%t` gets expanded into the current time in milliseconds, so each process gets its own log file. You can use prefixes and suffixes if you want, like this: `prefix-%t-suffix.log`. By derfault every isolate gets a separate log file.
+- `--logfile=%t.log` specifies a name pattern for log files. `%t` gets expanded into the current time in milliseconds, so each process gets its own log file. You can use prefixes and suffixes if you want, like this: `prefix-%t-suffix.log`. By default every isolate gets a separate log file.
 - `--prof` tells V8 to write statistical profiling information into the log file.
 
 ## Android
 
 Chrome on Android has a number of unique points that make it a bit more complex to profile.
 
-- The command line must be written via `adb` before starting Chrome on the device. As a result, quotes in the command line sometimes get lost, and it is best to seperate arguments in `--js-flags` with a comma rather than trying to use whitespace and quotes.
+- The command line must be written via `adb` before starting Chrome on the device. As a result, quotes in the command line sometimes get lost, and it is best to separate arguments in `--js-flags` with a comma rather than trying to use whitespace and quotes.
 - The path for the logfile must be specified as an absolute path to somewhere that is writable on Android’s filesystem.
 - The sandboxing used for renderer processes on Android means that even with `--no-sandbox`, the renderer process still can’t write to files on the filesystem, therefore `--single-process` needs to be passed to run the renderer in the same process as the browser process.
 - The `.so` is embedded in Chrome’s APK which means symbolization needs to convert from APK memory addresses to the unstripped `.so` file in the builds.

--- a/src/docs/torque.md
+++ b/src/docs/torque.md
@@ -199,7 +199,7 @@ When mapping union types to CSA, the most specific common supertype of all the t
 
 #### Class types
 
-Class types make it possible to define, allocate and manipulate structured objects on the V8 GC heap from Torque code. Each Torque class type must correspond to a subclass of HeapObject in C++ code. In order to minimize the expense of maintaining boilerplate object-accessing code between V8’s C++ and Torque implementation, the Torque class definitions are used to generate the required C++ object-accesing code whenever possible (and appropriate) to reduce the hassle of keeping C++ and Torque synchronized by hand.
+Class types make it possible to define, allocate and manipulate structured objects on the V8 GC heap from Torque code. Each Torque class type must correspond to a subclass of HeapObject in C++ code. In order to minimize the expense of maintaining boilerplate object-accessing code between V8’s C++ and Torque implementation, the Torque class definitions are used to generate the required C++ object-accessing code whenever possible (and appropriate) to reduce the hassle of keeping C++ and Torque synchronized by hand.
 
 ```grammar
 ClassDeclaration :
@@ -259,7 +259,7 @@ TNode<HeapObject> LoadJSProxyTarget(TNode<JSProxy> p_o);
 void StoreJSProxyTarget(TNode<JSProxy> p_o, TNode<HeapObject> p_v);
 ```
 
-As described above, the fields definied in Torque classes generate C++ code that removes the need for duplicate boilerplate accessor and heap visitor code. Because the example above uses `@generateCppClass`, the hand-written definition of JSProxy must inherit from a generated class template, like this:
+As described above, the fields defined in Torque classes generate C++ code that removes the need for duplicate boilerplate accessor and heap visitor code. Because the example above uses `@generateCppClass`, the hand-written definition of JSProxy must inherit from a generated class template, like this:
 
 ```cpp
 // In js-proxy.h:
@@ -632,7 +632,7 @@ Like `builtin`s and `runtime`s, `intrinsic`s cannot have labels.
 
 ### Explicit parameters
 
-Declarations of Torque-defined Callables, e.g. Torque `macro`s and `builtin`s, have explicit parameter lists. They are a list of identifier and type pairs using a syntax reminiscent of typed TypeScript function parameter lists, with the exception that Torque doesn’t support optional parameters or default parameters. Moreover, Torque-implement `builtin`s can optonally support rest parameters if the builtin uses V8’s internal JavaScript calling convention (e.g. is marked with the `javascript` keyword).
+Declarations of Torque-defined Callables, e.g. Torque `macro`s and `builtin`s, have explicit parameter lists. They are a list of identifier and type pairs using a syntax reminiscent of typed TypeScript function parameter lists, with the exception that Torque doesn’t support optional parameters or default parameters. Moreover, Torque-implement `builtin`s can optionally support rest parameters if the builtin uses V8’s internal JavaScript calling convention (e.g. is marked with the `javascript` keyword).
 
 ```grammar
 ExplicitParameters :

--- a/src/features/object-fromentries.md
+++ b/src/features/object-fromentries.md
@@ -107,7 +107,7 @@ Object.fromEntries(map);
 // stringify to the same value of '[object Object]'.
 ```
 
-Before using `Object.fromEntries` or any other techique to convert a map into a object, make sure the map’s keys produce unique `toString` results.
+Before using `Object.fromEntries` or any other technique to convert a map into a object, make sure the map’s keys produce unique `toString` results.
 
 ## `Object.fromEntries` support { #support }
 


### PR DESCRIPTION
Fixed several typos in `documentation` and a typo in `features`