### PR TITLE
chore: make inclusive language truly inclusive

### DIFF
--- a/src/docs/respectful-code.md
+++ b/src/docs/respectful-code.md
@@ -33,16 +33,16 @@ Apply the principles above. If you have any questions, you can reach out to `v8-
 This list is NOT meant to be comprehensive. It contains a few examples that people have run into frequently.
 
 :::table-wrapper
-| Term      | Suggested alternatives                                        |
-| --------- | ------------------------------------------------------------- |
-| master    | primary, controller, leader, host                             |
-| slave     | replica, subordinate, secondary, follower, device, peripheral |
-| whitelist | allowlist, exception list, inclusion list                     |
-| blacklist | denylist, blocklist, exclusion list                           |
-| insane    | unexpected, catastrophic, incoherent                          |
-| sane      | expected, appropriate, sensible, valid                        |
-| crazy     | unexpected, catastrophic, incoherent                          |
-| redline   | priority line, limit, soft limit                              |
+| Term      | Suggested alternatives                                             |
+| --------- | ------------------------------------------------------------------ |
+| master    | primary, controller, leader, host                                  |
+| slave     | replica, subordinate, secondary, follower, device, peripheral      |
+| whitelist | exception list, inclusion list, list of allowed X / allowed X list |
+| blacklist | exclusion list, list of blocked X / blocked X list                 |
+| insane    | unexpected, catastrophic, incoherent                               |
+| sane      | expected, appropriate, sensible, valid                             |
+| crazy     | unexpected, catastrophic, incoherent                               |
+| redline   | priority line, limit, soft limit                                   |
 :::
 
 ## What if I am interfacing with something that violates this policy? { #violations }


### PR DESCRIPTION
While "blocklist" / "denylist" and "allowlist" / "grantlist" or other alternatives are quite commonly proposed, they are neglecting something - English is not the only language spoken on our Earth. In many languages, these fabricated alternatives have no direct translations.

For instance, Spanish. None of those alternatives have translations that make sense. Not to mention that "whitelist" and "blacklist" are already inaccessible in those languages due to their rarity. The most commonly used phrasing is, for instance, "list of blocked users" or "blocked user list".

We need to be mindful of this when creating guidelines for inclusivity. We need to be TRULY inclusive, and considerate of those that come from foreign backgrounds, otherwise, you are actively making the terminology less accessible to more people than you are helping.

This is not to create a flame or attack anyone on the V8 development team. I just truly believe that this hasn't been considered enough, and I do not wish to see the second wave of realization when people wake up to the fact that many people from other linguistic backgrounds will struggle to understand these alternatives. Software engineering should be accessible to all, no matter the abstract features of their background.