### PR TITLE
optional-catch-binding.md: Correct supported Node

### DIFF
--- a/src/features/optional-catch-binding.md
+++ b/src/features/optional-catch-binding.md
@@ -37,5 +37,5 @@ try {
 <feature-support chrome="66 /blog/v8-release-66#optional-catch-binding"
                  firefox="58 https://bugzilla.mozilla.org/show_bug.cgi?id=1380881"
                  safari="yes https://trac.webkit.org/changeset/220068/webkit"
-                 nodejs="8"
+                 nodejs="10 https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#2018-04-24-version-1000-current-jasnell"
                  babel="yes"></feature-support>


### PR DESCRIPTION
Hi folks. I noticed the "support" info box at the bottom of https://v8.dev/features/optional-catch-binding has the wrong NodeJS version listed. It should be Node 10, but it lists Node 8.

(Optional catch binding is an ECMAScript 2019 feature... V8 first added support for this feature in V8 version 6.6. Node didn't update its V8 engine version to 6.6 until Node v10.0.0.)

See:
- https://v8.dev/blog/v8-release-66#optional-catch-binding
- https://github.com/nodejs/node/commit/9daebb48d6 (NodeJS commit updating V8 engine to version 6.6, landed in preparation for Node 10.0.0)
   - https://github.com/nodejs/node/pull/19201 (The corresponding pull request. Landed (as the above-linked commit) targeting a release in Node 10.0.0) 
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#2018-04-24-version-1000-current-jasnell

---

When I do `node -e 'console.log(process.versions)' with the latest Node 8.x, latest Node 9.x, and Node 10.0.0, I get...

```
  node: '8.17.0',
  v8: '6.2.414.78',
```

```
  node: '9.11.2',
  v8: '6.2.414.46-node.23',
```

```
  node: '10.0.0',
  v8: '6.6.346.24-node.5',
```

---

Testing with the following file reveals that Node 10 supports optional catch binding, Node 8 and 9 don't.

```js
// trycatch.js
try {
  throw new Error
} catch {
  console.log('Caught an error')
}
```

With Node 8 and 9, I get the following error:

```console
$ node trycatch.js 
/home/[user]/trycatch.js:4
} catch {
        ^

SyntaxError: Unexpected token {
```

With Node 10 I get the catch block executing properly, indicating optional catch binding is working:

```console
$ node trycatch.js 
Caught an error
```