### PR TITLE
Fixed Firefox support link for support of cause options on Error Constructor

### DIFF
--- a/src/features/error-cause.md
+++ b/src/features/error-cause.md
@@ -68,7 +68,7 @@ This feature is available in V8 v9.3.
 ## Error causes support { #support }
 
 <feature-support chrome="93 https://chromium-review.googlesource.com/c/v8/v8/+/2784681"
-                 firefox="yes https://bugzilla.mozilla.org/show_bug.cgi?id=1561074"
+                 firefox="no"
                  safari="yes https://github.com/WebKit/WebKit/commit/b03c4f4dada2c477376b9275332e08a3d08eba5f"
                  nodejs="no"
                  babel="no"></feature-support>

--- a/src/features/error-cause.md
+++ b/src/features/error-cause.md
@@ -68,7 +68,7 @@ This feature is available in V8 v9.3.
 ## Error causes support { #support }
 
 <feature-support chrome="93 https://chromium-review.googlesource.com/c/v8/v8/+/2784681"
-                 firefox="no"
+                 firefox="yes https://bugzilla.mozilla.org/show_bug.cgi?id=1679653"
                  safari="yes https://github.com/WebKit/WebKit/commit/b03c4f4dada2c477376b9275332e08a3d08eba5f"
                  nodejs="no"
                  babel="no"></feature-support>


### PR DESCRIPTION
The linked Bugzilla entry is something else.
~~I did not found something about it in Bugzilla.~~