### PR TITLE
[Error.cause] Fix switch statement

### DIFF
--- a/src/features/error-cause.md
+++ b/src/features/error-cause.md
@@ -52,7 +52,7 @@ function doWork() {
 try {
   doWork();
 } catch (err) {
-  switch(err) {
+  switch(err.message) {
     case 'Some work failed':
       handleSomeWorkFailure(err.cause);
       break;


### PR DESCRIPTION
In the example, we should match the values of the error message in the switch statement.