### PR TITLE
Simplify <meta name=viewport>

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>{% if '/' === page.url %}V8 JavaScript engine{% else %}{{ (renderData.title or title) | markdown | striptags | decodeHtmlEntities }} · V8{% endif %}</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width">
     <meta name="color-scheme" content="dark light">
     <link rel="stylesheet" href="/_css/main.css">
 {% if '/features' in page.url %}


### PR DESCRIPTION
`initial-scale=1` was only necessary for iOS Safari < 9 (to work around its orientation change bug). Nowadays, such ancient versions of iOS Safari are rarely used anymore.

Background: https://webhint.io/docs/user-guide/hints/hint-meta-viewport/