### PR TITLE
Update test.md to include information on regenerating inspector test expectations

### DIFF
--- a/src/docs/test.md
+++ b/src/docs/test.md
@@ -60,6 +60,20 @@ If you don’t want to run all the `JSTests`, you can provide a `filter` argumen
 tools/run_perf.py --arch x64 --binary-override-path out/x64.release/d8 --filter JSTests/TypedArrays test/js-perf-test/JSTests.json
 ```
 
+## Updating the inspector test expectations
+
+After updating your test, you might need to regenerate the expectations file for it. You can achieve this by running:
+
+```bash
+tools/run-tests.py --regenerate-expected-files --outdir=ia32.release inspector/debugger/set-instrumentation-breakpoint
+```
+
+This can also be useful if you want to find out how the output of your test changed. First regenerate the expected file using the command above, then check the diff with:
+
+```bash
+git diff
+```
+
 ## Updating the bytecode expectations (rebaselining)
 
 Sometimes the bytecode expectations may change resulting in `cctest` failures. To update the golden files, build `test/cctest/generate-bytecode-expectations` by running:


### PR DESCRIPTION
This includes documentation on how to regenerate the test expectations for inspector tests.