### PR TITLE
Fix node integration instructions

### DIFF
--- a/src/docs/node-integration.md
+++ b/src/docs/node-integration.md
@@ -42,8 +42,8 @@ Add your both your fork and V8’s fork as remotes to the existing checkout:
 ```bash
 cd node
 git remote add v8 http://github.com/v8/node
-git remote add <your-user-name> http://github.com/<your-user-name>/node
-git fetch
+git remote add <your-user-name> git@github.com:<your-user-name>/node.git
+git fetch v8
 git checkout node-ci-<sync-date>
 export BRANCH_NAME=`date +"%Y-%m-%d"`_fix_name
 git checkout -b $BRANCH_NAME


### PR DESCRIPTION
Fix 1: git fetch is not always enough, git fetch v8 should work
Fix 2: clone the fork by using ssh, not https; github has disabled pushing via https+password auth