### PR TITLE
Fix link to d8 source directory in chromium repo

### DIFF
--- a/src/docs/d8.md
+++ b/src/docs/d8.md
@@ -2,7 +2,7 @@
 title: 'Using `d8`'
 description: 'd8 is V8’s own developer shell.'
 ---
-[`d8`](https://codesearch.chromium.org/chromium/src/v8/src/d8.h?q=d8&sq=package:chromium&l=5) is V8’s own developer shell.
+[`d8`](https://source.chromium.org/chromium/chromium/src/+/main:v8/src/d8/) is V8’s own developer shell.
 
 `d8` is useful for running some JavaScript locally or debugging changes you have made to V8. [Building V8 using GN](/docs/build-gn) for x64 outputs a `d8` binary in `out.gn/x64.optdebug/d8`. You can call `d8` with the  `--help` argument for more information about usage and flags.
 


### PR DESCRIPTION
The old link doesn't work anymore.