### PR TITLE
Update linux-perf.md

### DIFF
--- a/src/docs/linux-perf.md
+++ b/src/docs/linux-perf.md
@@ -2,60 +2,27 @@
 title: 'V8’s Linux `perf` integration'
 description: 'This document explains how to analyze the performance of V8’s JITted code with the Linux `perf` tool.'
 ---
-V8 has built-in support for the Linux `perf` tool. By default, this support is disabled, but by using the `--perf-prof` and `--perf-prof-debug-info` command-line options, V8 writes out performance data during execution into a file that can be used to analyze the performance of V8’s JITted code with the Linux `perf` tool.
+V8 has built-in support for the Linux `perf` tool. It is enable by the `--perf-prof` command-line options.
+V8 writes out performance data during execution into a file that can be used to analyze the performance of V8’s JITted code (including JS-function names) with the Linux `perf` tool.
 
-## Optional: Get recent kernel and `perf`
+## Requirements
 
-In order to analyze V8 JIT code with the Linux `perf` tool, you need to:
+- `linux-perf` version 5 or higher (previous version don't have jit support). (See instructions at the [end](#build-perf))
+- Build V8/Chrome with `enable_profiling=true` for better symbolized stacks
 
-- Use a recent Linux kernel that provides high-resolution timing information to the `perf` tool and to V8’s `perf` integration in order to synchronize JIT code performance samples with the standard performance data collected by the Linux `perf` tool.
-- Use a recent version of the Linux `perf` tool or apply the patch that supports JIT code to `perf` and build it yourself.
-
-Install a new Linux kernel, and then reboot your machine:
-
-```bash
-sudo apt-get install linux-generic-lts-wily
-```
-
-Install dependencies:
-
-```bash
-sudo apt-get install libdw-dev libunwind8-dev systemtap-sdt-dev libaudit-dev \
-    libslang2-dev binutils-dev liblzma-dev
-```
-
-Download kernel sources that include the latest `perf` tool source:
-
-```bash
-cd <path_to_kernel_checkout>
-git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
-cd tip/tools/perf
-make
-```
-
-In the following steps, invoke `perf` as `<path_to_kernel_checkout>/tip/tools/perf/perf`.
 
 ## Build V8
 
-To use V8’s integration with Linux perf you need to build it with the appropriate GN build flag activated. You can set `enable_profiling = true` in an existing GN build configuration.
+To use V8’s integration with Linux perf you need to build it with the `enable_profiling = true` gn flag:
 
 ```bash
 echo 'enable_profiling = true' >> out/x64.release/args.gn
 ninja -C out/x64.release
 ```
 
-Alternatively, you create a new clean build configuration with only the single build flag set to enable `perf` support:
+## Profiling `d8` with perf flags
 
-```bash
-cd <path_to_your_v8_checkout>
-gn gen out/x64.release \
-    --args='is_debug=false target_cpu="x64" enable_profiling=true'
-ninja -C out/x64.release
-```
-
-## Running `d8` with perf flags
-
-Once you have the right kernel, perf tool and build of V8, you can start using linux perf:
+After building `d8`, you can start using linux perf:
 
 ```bash
 cd <path_to_your_v8_checkout>
@@ -63,10 +30,12 @@ echo '(function f() {
     var s = 0; for (var i = 0; i < 1000000000; i++) { s += i; } return s;
   })();' > test.js
 perf record -g -k mono out/x64.release/d8 \
-    --perf-prof --no-write-protect-code-memory test.js
+    --perf-prof --no-write-protect-code-memory \
+    --interpreted-frames-native-stack \
+    test.js
 ```
 
-### Flags description
+## V8 linux-perf Flags
 
 [`--perf-prof`](https://source.chromium.org/search?q=FLAG_perf_prof) is used to the V8 command-line to record performance samples in JIT code.
 
@@ -74,42 +43,96 @@ perf record -g -k mono out/x64.release/d8 \
 
 [`--interpreted-frames-native-stack`](https://source.chromium.org/search?q=FLAG_interpreted_frames_native_stack) is used to create different entry points (copied versions of InterpreterEntryTrampoline) for interpreted functions so they can be distinguished by `perf` based on the address alone.
 
-## Running `chrome` with perf flags
 
-1. You can use the same V8 flags to profile chrome itself. Follow the instructions above for the correct V8 flags and add the [required chrome gn flags](https://chromium.googlesource.com/chromium/src/+/master/docs/profiling.md#preparing-your-checkout) to your chrome build.
+## Profiling chrome with the [linux-perf.py](https://source.chromium.org/search?q=linux-perf.py) script
+
+1. You can use the same V8 flags to profile chrome itself. Follow the instructions above for the correct V8 flags and add the [required chrome gn flags](https://chromium.googlesource.com/chromium/src/+/master/docs/profiling.md#General-checkout-setup) to your chrome build.
 
 1. Once your build is ready, you can profile a website with both, full symbols for C++ and JS code.
 
-    ```
-    out/x64.release/chrome --user-data-dir=`mktemp -d` --no-sandbox --incognito \
-        --js-flags='--perf-prof --no-write-protect-code-memory --interpreted-frames-native-stack'
-    ```
-
-1. After starting up chrome, find the renderer process id using the Task Manager and use it to start profiling:
-
-    ```
-    perf record -g -k mono -p $RENDERER_PID -o perf.data
+    ```bash
+    mkdir perf_results;
+    tools/chrome/linux-perf.py out/x64.release/chrome --perf-data-dir=perf_results --timeout=30
     ```
 
-1. Navigate to your website and then continue with the next section on how to evaluate the perf output.
+2. Navigate to your website and then close the browser (or wait for the `--timeout` to complete)
+3. After quitting the browser `linux-perf.py` will post-process the files and show a list with a result file for each renderer process:
+  
+   ```
+   chrome_renderer_1583105_3.perf.data.jitted      19.79MiB
+   chrome_renderer_1583105_2.perf.data.jitted       8.59MiB
+   chrome_renderer_1583105_4.perf.data.jitted       0.18MiB
+   chrome_renderer_1583105_1.perf.data.jitted       0.16MiB
+   ```
 
-## Evaluating perf output
+## Explore linux-perf results
 
-After execution finishes, you must combine the static information gathered from the `perf` tool with the performance samples output by V8 for JIT code:
-
-```bash
-perf inject -j -i perf.data -o perf.data.jitted
-```
-
-Finally you can use the Linux `perf` tool to explore the performance bottlenecks in your JITted code:
+Finally you can use the Linux `perf` tool to explore the profile of a d8 or chrome renderer process:
 
 ```bash
 perf report -i perf.data.jitted
 ```
 
-You can also convert `perf.data.jitted` file with [perf_to_profile](https://github.com/google/perf_data_converter) to work with [pprof](https://github.com/google/pprof) to generate more visualizations:
+You can also use [pprof](https://github.com/google/pprof) to generate more visualizations:
 
+```bash
+pprof -flame perf.data.jitted;
 ```
-~/Documents/perf_data_converter/bazel-bin/src/perf_to_profile -j -i perf.data.jitted -o out.prof;
-pprof -http out.prof;
-```
+
+
+## Using linux-perf with chrome directly
+
+1. You can use the same V8 flags to profile chrome itself. Follow the instructions above for the correct V8 flags and add the [required chrome gn flags](https://chromium.googlesource.com/chromium/src/+/master/docs/profiling.md#General-checkout-setup) to your chrome build.
+
+1. Once your build is ready, you can profile a website with both, full symbols for C++ and JS code.
+
+    ```bash
+    out/x64.release/chrome \
+        --user-data-dir=`mktemp -d` \
+        --no-sandbox --incognito --enable-benchmarking \
+        --js-flags='--perf-prof --no-write-protect-code-memory --interpreted-frames-native-stack'
+    ```
+
+1. After starting up chrome, find the renderer process id using the Task Manager and use it to start profiling:
+
+    ```bash
+    perf record -g -k mono -p $RENDERER_PID -o perf.data
+    ```
+
+1. Navigate to your website and then continue with the next section on how to evaluate the perf output.
+
+2. After execution finishes, combine the static information gathered from the `perf` tool with the performance samples output by V8 for JIT code:
+
+   ```bash
+   perf inject -j -i perf.data -o perf.data.jitted
+   ```
+
+3 Finally you can use the Linux `perf` [tool to explore](#Explore-linux-perf-results) 
+
+
+
+## Build `perf`
+
+If you have an outdated linux kernel you can build linux-perf with jit support locally.
+
+- Install a new Linux kernel, and then reboot your machine:
+  ```bash
+   sudo apt-get install linux-generic-lts-wily;
+  ```
+
+- Install dependencies:
+  ```bash
+  sudo apt-get install libdw-dev libunwind8-dev systemtap-sdt-dev libaudit-dev \
+     libslang2-dev binutils-dev liblzma-dev;
+  ```
+
+- Download kernel sources that include the latest `perf` tool source:
+
+  ```bash
+  cd some/directory;
+  git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git;
+  cd tip/tools/perf;
+  make
+  ```
+
+In the following steps, invoke `perf` as `some/director/tip/tools/perf/perf`.

--- a/src/docs/linux-perf.md
+++ b/src/docs/linux-perf.md
@@ -10,7 +10,6 @@ V8 writes out performance data during execution into a file that can be used to 
 - `linux-perf` version 5 or higher (previous version don't have jit support). (See instructions at the [end](#build-perf))
 - Build V8/Chrome with `enable_profiling=true` for better symbolized stacks
 
-
 ## Build V8
 
 To use V8’s integration with Linux perf you need to build it with the `enable_profiling = true` gn flag:
@@ -105,7 +104,7 @@ pprof -flame perf.data.jitted;
    perf inject -j -i perf.data -o perf.data.jitted
    ```
 
-1. Finally you can use the Linux `perf` [tool to explore](#Explore-linux-perf-results) 
+1. Finally you can use the Linux `perf` [tool to explore](#Explore-linux-perf-results)
 
 ## Build `perf`
 

--- a/src/docs/linux-perf.md
+++ b/src/docs/linux-perf.md
@@ -43,7 +43,6 @@ perf record -g -k mono out/x64.release/d8 \
 
 [`--interpreted-frames-native-stack`](https://source.chromium.org/search?q=FLAG_interpreted_frames_native_stack) is used to create different entry points (copied versions of InterpreterEntryTrampoline) for interpreted functions so they can be distinguished by `perf` based on the address alone.
 
-
 ## Profiling chrome with the [linux-perf.py](https://source.chromium.org/search?q=linux-perf.py) script
 
 1. You can use the same V8 flags to profile chrome itself. Follow the instructions above for the correct V8 flags and add the [required chrome gn flags](https://chromium.googlesource.com/chromium/src/+/master/docs/profiling.md#General-checkout-setup) to your chrome build.
@@ -55,8 +54,8 @@ perf record -g -k mono out/x64.release/d8 \
     tools/chrome/linux-perf.py out/x64.release/chrome --perf-data-dir=perf_results --timeout=30
     ```
 
-2. Navigate to your website and then close the browser (or wait for the `--timeout` to complete)
-3. After quitting the browser `linux-perf.py` will post-process the files and show a list with a result file for each renderer process:
+1. Navigate to your website and then close the browser (or wait for the `--timeout` to complete)
+1. After quitting the browser `linux-perf.py` will post-process the files and show a list with a result file for each renderer process:
   
    ```
    chrome_renderer_1583105_3.perf.data.jitted      19.79MiB
@@ -79,7 +78,6 @@ You can also use [pprof](https://github.com/google/pprof) to generate more visua
 pprof -flame perf.data.jitted;
 ```
 
-
 ## Using linux-perf with chrome directly
 
 1. You can use the same V8 flags to profile chrome itself. Follow the instructions above for the correct V8 flags and add the [required chrome gn flags](https://chromium.googlesource.com/chromium/src/+/master/docs/profiling.md#General-checkout-setup) to your chrome build.
@@ -101,26 +99,26 @@ pprof -flame perf.data.jitted;
 
 1. Navigate to your website and then continue with the next section on how to evaluate the perf output.
 
-2. After execution finishes, combine the static information gathered from the `perf` tool with the performance samples output by V8 for JIT code:
+1. After execution finishes, combine the static information gathered from the `perf` tool with the performance samples output by V8 for JIT code:
 
    ```bash
    perf inject -j -i perf.data -o perf.data.jitted
    ```
 
-3 Finally you can use the Linux `perf` [tool to explore](#Explore-linux-perf-results) 
-
-
+1. Finally you can use the Linux `perf` [tool to explore](#Explore-linux-perf-results) 
 
 ## Build `perf`
 
 If you have an outdated linux kernel you can build linux-perf with jit support locally.
 
 - Install a new Linux kernel, and then reboot your machine:
+
   ```bash
    sudo apt-get install linux-generic-lts-wily;
   ```
 
 - Install dependencies:
+
   ```bash
   sudo apt-get install libdw-dev libunwind8-dev systemtap-sdt-dev libaudit-dev \
      libslang2-dev binutils-dev liblzma-dev;


### PR DESCRIPTION
- Simplify the instructions given that the current linux distributions have recent-enough version of linux-perf with jit support installed.
- Mention using the new linux-perf.py script that simplifies profiling chrome and it's renderers