### PR TITLE
Less strict markdownlint

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -26,6 +26,9 @@
       "video"
     ]
   },
+  "ol-prefix": false,
+  "no-multiple-blanks": false,
+  "no-trailing-spaces": false,
   "fenced-code-language": false,
   "no-alt-text": false
 }


### PR DESCRIPTION
Simplify linter rules that make quick edits cumbersome and have no effect on the rendered document.
Ideally these could be fixed by an auto-formatting tool, but since we don't have this we should opt for ease of editing.