### PR TITLE
add return type explicitly to Torque sample code

### DIFF
--- a/src/docs/torque.md
+++ b/src/docs/torque.md
@@ -18,7 +18,7 @@ Begin by opening up the `test/torque/test-torque.tq` file and add the following 
 
 ```torque
 @export
-macro PrintHelloWorld() {
+macro PrintHelloWorld(): void {
   Print('Hello world!');
 }
 ```


### PR DESCRIPTION
Since implicit return type `void` is deprecated,  `void` is added explicitly to the Torque hello world sample code.

```
Torque Error: Default void return types are deprecated. Add `: void`.
```