### PR TITLE
Update embed.md to resolve samples crash

### DIFF
--- a/src/docs/embed.md
+++ b/src/docs/embed.md
@@ -48,7 +48,7 @@ Follow the steps below to run the example yourself:
 1. Compile `hello-world.cc`, linking to the static library created in the build process. For example, on 64bit Linux using the GNU compiler:
 
     ```bash
-    g++ -I. -Iinclude samples/hello-world.cc -o hello_world -fno-rtti -lv8_monolith -lv8_libbase -lv8_libplatform -ldl -Lout.gn/x64.release.sample/obj/ -pthread -std=c++17 -DV8_COMPRESS_POINTERS
+    g++ -I. -Iinclude samples/hello-world.cc -o hello_world -fno-rtti -lv8_monolith -lv8_libbase -lv8_libplatform -ldl -Lout.gn/x64.release.sample/obj/ -pthread -std=c++17 -DV8_COMPRESS_POINTERS -DV8_ENABLE_SANDBOX
     ```
 
 1. For more complex code, V8 fails without an ICU data file. Copy this file to where your binary is stored:


### PR DESCRIPTION
On the compile line for hello_world.cc, you also need -DV8_ENABLE_SANDBOX, or else the sample will crash when run