### PR TITLE
Add tags to feed entry `<id>`s

### DIFF
--- a/src/blog.atom.njk
+++ b/src/blog.atom.njk
@@ -19,7 +19,7 @@ excludeFromSitemap: true
     <title>{{ post.data.title }}</title>
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ (post.data.updated or post.date) | rssDate }}</updated>
-    <id>{{ absolutePostUrl }}</id>
+    <id>{% for tag in post.data.tags %}{% if not 'io' in tag and not 'Node.js' in tag %}{{ tag | slug }}:{% endif %}{% endfor %}{{ absolutePostUrl }}</id>
     <author>
       <name>{{ post.data.author | markdown | striptags }}</name>
     </author>

--- a/src/blog.atom.njk
+++ b/src/blog.atom.njk
@@ -19,7 +19,12 @@ excludeFromSitemap: true
     <title>{{ post.data.title }}</title>
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ (post.data.updated or post.date) | rssDate }}</updated>
-    <id>{% for tag in post.data.tags %}{% if not 'io' in tag and not 'Node.js' in tag %}{{ tag | slug }}:{% endif %}{% endfor %}{{ absolutePostUrl }}</id>
+    <id>{{ absolutePostUrl }}</id>
+    {%- for tag in post.data.tags %}
+      {%- if not 'io' in tag and not 'Node.js' in tag %}
+        <category term="{{ tag | slug }}" />
+      {%- endif %}
+    {%- endfor %}
     <author>
       <name>{{ post.data.author | markdown | striptags }}</name>
     </author>

--- a/src/blog.atom.njk
+++ b/src/blog.atom.njk
@@ -22,7 +22,7 @@ excludeFromSitemap: true
     <id>{{ absolutePostUrl }}</id>
     {%- for tag in post.data.tags %}
       {%- if not 'io' in tag and not 'Node.js' in tag %}
-        <category term="{{ tag | slug }}" />
+        <category label="{{ tag }}" term="{{ tag | slug }}" />
       {%- endif %}
     {%- endfor %}
     <author>

--- a/src/features.atom.njk
+++ b/src/features.atom.njk
@@ -19,7 +19,7 @@ excludeFromSitemap: true
     <title>{{ post.data.title }}</title>
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ (post.data.updated or post.date) | rssDate }}</updated>
-    <id>{{ absolutePostUrl }}</id>
+    <id>{% for tag in post.data.tags %}{% if not 'io' in tag and not 'Node.js' in tag %}{{ tag | slug }}:{% endif %}{% endfor %}{{ absolutePostUrl }}</id>
     <author>
       <name>{{ post.data.author | markdown | striptags }}</name>
     </author>

--- a/src/features.atom.njk
+++ b/src/features.atom.njk
@@ -19,7 +19,12 @@ excludeFromSitemap: true
     <title>{{ post.data.title }}</title>
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ (post.data.updated or post.date) | rssDate }}</updated>
-    <id>{% for tag in post.data.tags %}{% if not 'io' in tag and not 'Node.js' in tag %}{{ tag | slug }}:{% endif %}{% endfor %}{{ absolutePostUrl }}</id>
+    <id>{{ absolutePostUrl }}</id>
+    {%- for tag in post.data.tags %}
+      {%- if not 'io' in tag and not 'Node.js' in tag %}
+        <category term="{{ tag | slug }}" />
+      {%- endif %}
+    {%- endfor %}
     <author>
       <name>{{ post.data.author | markdown | striptags }}</name>
     </author>

--- a/src/features.atom.njk
+++ b/src/features.atom.njk
@@ -22,7 +22,7 @@ excludeFromSitemap: true
     <id>{{ absolutePostUrl }}</id>
     {%- for tag in post.data.tags %}
       {%- if not 'io' in tag and not 'Node.js' in tag %}
-        <category term="{{ tag | slug }}" />
+        <category label="{{ tag }}" term="{{ tag | slug }}" />
       {%- endif %}
     {%- endfor %}
     <author>


### PR DESCRIPTION
Over on web.dev, we plan to dynamically link to blog posts tagged with `WebAssembly` on your site. Therefore, I have annotated the feeds with the tags in the `<id>`, which is what the [RFC does](https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.6:~:text=%3Cid%3Etag%3Aexample.org%2C2003%3A3%3C/id%3E). This will allow us to parse out the relevant posts  from your feed.

```xml
<entry>
    <title>Introducing the WebAssembly JavaScript Promise Integration API</title>
    <link href="https://v8.dev/blog/jspi"/>
    <updated>2023-01-19T00:00:00Z</updated>
    <!-- Here 👇 -->
    <id>webassembly:https://v8.dev/blog/jspi</id>
    <author>
      <name>Francis McCabe, Thibaud Michaud, Ilya Rezvov, Brendan Dahl</name>
    </author>
    <content type="html">[…]</content>
  </entry>
```