### PR TITLE
Stack Trace API: Remove CallSite.IsPromiseAny which is not exposed

### DIFF
--- a/src/docs/stack-trace-api.md
+++ b/src/docs/stack-trace-api.md
@@ -102,7 +102,6 @@ The structured stack trace is an array of `CallSite` objects, each of which repr
 - `isConstructor`: is this a constructor call?
 - `isAsync`: is this an async call (i.e. `await`, `Promise.all()`, or `Promise.any()`)?
 - `isPromiseAll`: is this an async call to `Promise.all()`?
-- `isPromiseAny`: is this an async call to `Promise.any()`?
 - `getPromiseIndex`: returns the index of the promise element that was followed in `Promise.all()` or `Promise.any()` for async stack traces, or `null` if the `CallSite` is not an async `Promise.all()` or `Promise.any()` call.
 
 The default stack trace is created using the CallSite API so any information that is available there is also available through this API.


### PR DESCRIPTION
This method is not registered on the JS `CallSite` object.