### PR TITLE
Update cross-compile-ios.md to remove bitcode arg

### DIFF
--- a/src/docs/cross-compile-ios.md
+++ b/src/docs/cross-compile-ios.md
@@ -31,7 +31,6 @@ This section shows how to build a monolithic V8 version for use on either a phys
 Set up GN build files by running `gn args out/release-ios` and inserting the following keys:
 
 ```python
-enable_ios_bitcode = true
 ios_deployment_target = 10
 is_component_build = false
 is_debug = false


### PR DESCRIPTION
According to [Xcode 14 documentation](https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-14-release-notes#Deprecations): 

> Xcode no longer builds bitcode by default and generates a warning message if a project explicitly enables bitcode: “Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode.” The capability to build with bitcode will be removed in a future Xcode release.

This has been removed for other projects e.g. Chromium a while a go https://bugs.chromium.org/p/chromium/issues/detail?id=1335872