### PR TITLE
Update cross-compile-ios.md to remove use_xcode_clang arg

### DIFF
--- a/src/docs/cross-compile-ios.md
+++ b/src/docs/cross-compile-ios.md
@@ -37,7 +37,6 @@ is_debug = false
 target_cpu = "arm64"                  # "x64" for a simulator build.
 target_os = "ios"
 use_custom_libcxx = false             # Use Xcode's libcxx.
-use_xcode_clang = true
 v8_enable_i18n_support = false        # Produces a smaller binary.
 v8_monolithic = true                  # Enable the v8_monolith target.
 v8_use_external_startup_data = false  # The snaphot is included in the binary.


### PR DESCRIPTION
`use_xcode_clang` arg is not used anymore. Please refer to https://bugs.chromium.org/p/chromium/issues/detail?id=1266466. This is even generating a warning when setting up GN build files:

```
WARNING at build arg file (use "gn args <out_dir>" to edit):6:19: Build argument has no effect.
use_xcode_clang = true
                  ^---
The variable "use_xcode_clang" was set as a build argument
but never appeared in a declare_args() block in any buildfile.
```