### PR TITLE
Avoid auto-darkening on Flutter Wasm screenshot

### DIFF
--- a/src/blog/wasm-gc-porting.md
+++ b/src/blog/wasm-gc-porting.md
@@ -203,7 +203,7 @@ Overall, in WasmMVP there was a fairly clear separation between toolchain and VM
 
 You can use WasmGC today! After reaching [phase 4](https://github.com/WebAssembly/meetings/blob/main/process/phases.md#4-standardize-the-feature-working-group) at the W3C, WasmGC is now a full and finalized standard, and Chrome 119 shipped with support for it. With that browser (or any other browser that has WasmGC support; for example, Firefox 120 is expected to launch with WasmGC support later this month) you can run this [Flutter demo](https://flutterweb-wasm.web.app/) in which Dart compiled to WasmGC drives the application’s logic, including its widgets, layout, and animation.
 
-![The Flutter demo running in Chrome 119.](/_img/wasm-gc-porting/flutter-wasm-demo.png "Material 3 rendered by Flutter WasmGC.")
+![The Flutter demo running in Chrome 119.](/_img/wasm-gc-porting/flutter-wasm-demo.png "Material 3 rendered by Flutter WasmGC."){ .no-darkening }
 
 ## Getting started
 


### PR DESCRIPTION
The Flutter Wasm screenshot near the end of https://v8.dev/blog/wasm-gc-porting is quite jarring with the automatic color inversion and hue rotation when dark mode is enabled.

This PR adds the `.no-darkening` class since the original screenshot in dark mode works well in light and dark mode.

**Before:**

<img width="320" alt="Flutter wasm screenshot with automatic inversion" src="https://github.com/v8/v8.dev/assets/18372958/897f9abc-095f-42d3-95c0-e6863daeae13">

**After:**

<img width="320" alt="Flutter wasm screenshot with automatic inversion disabled" src="https://github.com/v8/v8.dev/assets/18372958/073dc03c-8316-4ebc-abe2-d30060a021ee">

Thanks for the great article by the way!
