### PR TITLE
Fix targeted footnotes in dark mode

### DIFF
--- a/src/_css/main.css
+++ b/src/_css/main.css
@@ -191,7 +191,13 @@ hr {
   font-size: 0.8em;
 }
 .footnote-item:target {
-  background: var(--lightyellow);
+  background-color: var(--lightyellow);
+  --html-color: var(--black);
+  --main-background: var(--white);
+  --main-and-footer-link-color: var(--darkblue);
+}
+.footnote-item:target > * {
+  color: var(--html-color);
 }
 .retweet {
   display: inline-block;


### PR DESCRIPTION
Before:

![Screenshot 2024-02-09 at 16 12 30](https://github.com/v8/v8.dev/assets/145676/e72b35dd-3a7c-48d1-97b8-fd54b9ae8546)

After:

![Screenshot 2024-02-09 at 16 11 58](https://github.com/v8/v8.dev/assets/145676/777b26bc-d091-4476-bfeb-06155f363b6c)
![Screenshot 2024-02-09 at 16 12 09](https://github.com/v8/v8.dev/assets/145676/0d80708f-164f-4fc3-b129-65c997213272)
