### PR TITLE
Fix local cache taking 1y to expire

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -79,16 +79,12 @@
         "source": "/sw.js",
         "headers": [
           {
-            "key": "Cache-Control",
-            "value": "no-cache"
-          },
-          {
             "key": "Content-Type",
             "value": "text/javascript;charset=utf-8"
           },
           {
             "key": "Cache-Control",
-            "value": "max-age=31557600"
+            "value": "public, max-age=600, stale-while-revalidate=3600"
           }
         ]
       },


### PR DESCRIPTION
The serviceworker config in the generated sw.js contains the revision of cached pages. Client-side these revisions are used by Workbox to invalidate the local cache. The local cache strategy is `precacheAndRoute`. As long as `sw.js` is not refreshed the local cache is not invalidated and stale pages are served indefinetly.

The current policy for `sw.js` was 1 year, which probably was a bug, since there is also a shadowed `no-cache` config.