### PR TITLE
Small cleanups

### DIFF
--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -8,7 +8,7 @@ This documentation is aimed at C++ developers who want to use V8 in their applic
 
 ## About V8
 
-V8 implements <a href="https://tc39.es/ecma262/">ECMAScript</a> and <a href="https://webassembly.github.io/spec/core/">WebAssembly</a>, and runs on Windows 7 or later, macOS 10.12+, and Linux systems that use x64, IA-32, or ARM processors. Additional systems (IBM i, AIX) and processors (MIPS, ppcle64, s390x) are externally maintained, see [ports](/docs/ports). V8 can run standalone, or can be embedded into any C++ application.
+V8 implements <a href="https://tc39.es/ecma262/">ECMAScript</a> and <a href="https://webassembly.github.io/spec/core/">WebAssembly</a>, and runs on Windows, macOS, and Linux systems that use x64, IA-32, or ARM processors. Additional systems (IBM i, AIX) and processors (MIPS, ppcle64, s390x) are externally maintained, see [ports](/docs/ports). V8 can be embedded into any C++ application.
 
 V8 compiles and executes JavaScript source code, handles memory allocation for objects, and garbage collects objects it no longer needs. V8’s stop-the-world, generational, accurate garbage collector is one of the keys to V8’s performance.
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -5,7 +5,7 @@ description: 'V8 is Google’s open source high-performance JavaScript and WebAs
 ---
 <h1>What is V8?</h1>
 
-<p>V8 is Google’s open source high-performance JavaScript and WebAssembly engine, written in C++. It is used in Chrome and in Node.js, among others. It implements <a href="https://tc39.es/ecma262/">ECMAScript</a> and <a href="https://webassembly.github.io/spec/core/">WebAssembly</a>, and runs on Windows 7 or later, macOS 10.12+, and Linux systems that use x64, IA-32, ARM, or MIPS processors. V8 can run standalone, or can be embedded into any C++ application.</p>
+<p>V8 is Google’s open source high-performance JavaScript and WebAssembly engine, written in C++. It is used in Chrome and in Node.js, among others. It implements <a href="https://tc39.es/ecma262/">ECMAScript</a> and <a href="https://webassembly.github.io/spec/core/">WebAssembly</a>, and runs on Windows, macOS, and Linux systems that use x64, IA-32, or ARM processors. V8 can be embedded into any C++ application.</p>
 
 <h2>Latest posts and feature explainers</h2>
 


### PR DESCRIPTION
The description said that V8 can be executed standalone, which is incorrect. V8 always needs an embedder, and d8 is just one of the embedders of V8.

Moreover, the versions of operating systems got removed. Chrome does not support Windows 7 anymore, so V8 probably also does not support Windows 7 anymore. Since we don't keep the version numbers on v8.dev up to date, it's better to just remove them.

Additionally the first-party support for Mips was removed.