### PR TITLE
Update intro JSPI blog entry

### DIFF
--- a/src/blog/jspi.md
+++ b/src/blog/jspi.md
@@ -2,7 +2,7 @@
 title: 'Introducing the WebAssembly JavaScript Promise Integration API'
 description: 'This document introduces JSPI and provides some simple examples to get you started in using it'
 author: 'Francis McCabe, Thibaud Michaud, Ilya Rezvov, Brendan Dahl'
-date: 2024-06-20
+date: 2024-07-01
 tags:
   - WebAssembly
 ---


### PR DESCRIPTION
Have tidied up original blog post entry introducing JSPI.

It is slightly more 'timeless' and should (mostly) survive external events to do with standardization.