### PR TITLE
Update Committer Guidelines

### DIFF
--- a/src/docs/become-committer.md
+++ b/src/docs/become-committer.md
@@ -2,7 +2,7 @@
 title: 'Becoming a committer'
 description: 'How does one become a V8 committer? This document explains.'
 ---
-Technically, committers are people who have write access to the V8 Git repository. Committers can submit their own patches or patches from others.
+Technically, committers are people who have write access to the V8 repository. All patches need to be reviewed by at least two committers (including the author). Independently from this requirement, patches also need to be authored or reviewed by an OWNER.
 
 This privilege is granted with some expectation of responsibility: committers are people who care about the V8 project and want to help meet its goals. Committers are not just people who can make changes, but people who have demonstrated their ability to collaborate with the team, get the most knowledgeable people to review code, contribute high-quality code, and follow through to fix issues (in code or tests).
 
@@ -23,24 +23,22 @@ In a nutshell, contribute 20 non-trivial patches and get at least three differen
 A current committer nominates you by sending email to <v8-committers@googlegroups.com> containing:
 
 - your first and last name
-- your Google Code email address
+- your email address in Gerrit
 - an explanation of why you should be a committer,
 - embedded list of links to revisions (about top 10) containing your patches
 
-Two other committers need to second your nomination. If no one objects in 5 working days (U.S.), you're a committer.  If anyone objects or wants more information, the committers discuss and usually come to a consensus (within the 5 working days). If issues cannot be resolved, there's a vote among current committers.
+Two other committers need to second your nomination. If no one objects in 5 working days, you're a committer.  If anyone objects or wants more information, the committers discuss and usually come to a consensus (within the 5 working days). If issues cannot be resolved, there's a vote among current committers.
 
-Once you get approval from the existing committers, we'll send you instructions for write access to Git. You'll also be added to v8-committers@googlegroups.com.
+Once you get approval from the existing committers, you are granted additional review permissions. You'll also be added to the mailing list v8-committers@googlegroups.com.
 
-In the worst case, this can drag out for two weeks. Keep writing patches! Even in the rare cases where a nomination fails, the objection is usually something easy to address like “more patches” or “not enough people are familiar with this person’s work.”
-
-### Setting up push access to the repository
-
-When you are accepted as a committer make sure to [set up push access to the repo](/docs/source-code#instructions).
+In the worst case, the process can drag out for two weeks. Keep writing patches! Even in the rare cases where a nomination fails, the objection is usually something easy to address like “more patches” or “not enough people are familiar with this person’s work.”
 
 ## Maintaining committer status
 
 You don't really need to do much to maintain committer status: just keep being awesome and helping the V8 project!
 
 In the unhappy event that a committer continues to disregard good citizenship (or actively disrupts the project), we may need to revoke that person's status. The process is the same as for nominating a new committer: someone suggests the revocation with a good reason, two people second the motion, and a vote may be called if consensus cannot be reached. I hope that's simple enough, and that we never have to test it in practice.
+
+In addition, as a security measure, if you are inactive on Gerrit (no upload, no comment and no review) for more than a year, we may revoke your committer privileges. An email notification is sent about 7 days prior to the removal. This is not meant as a punishment, so if you wish to resume contributing after that, contact v8-committers@googlegroups.com to ask that it be restored, and we will normally do so.
 
 (This document was inspired by <https://dev.chromium.org/getting-involved/become-a-committer>.)


### PR DESCRIPTION
In Chromium's efforts to make development more secure, an update to the committer guidelines is required: This PR adds a paragraph regarding removals of inactive committers. See https://crbug.com/350501622 (Google internal) for details.

Additionally, it updates some wordings to be more aligned with V8's current processes.